### PR TITLE
Support to Multithreading

### DIFF
--- a/GameTemplate/addons/GameTemplate/Utility/ResourceAsyncLoader.gd
+++ b/GameTemplate/addons/GameTemplate/Utility/ResourceAsyncLoader.gd
@@ -1,4 +1,4 @@
-class_name ResourceAsyncLoader	#Godot 3.2.2
+class_name ResourceAsyncLoader  #Godot 3.2.2
 
 #USE IT LIKE THIS
 #var loader = ResourceAsyncLoader_GT.new()
@@ -12,28 +12,53 @@ var mutex: = Mutex.new()
 
 var can_async:bool = OS.can_use_threads()
 
+func split_work(work:int, workers:int, vector:Array)->Array:
+  var step = int(work / workers)
+  var remainder = work % workers
+  var return_vector = []
+  var begin = 0
+  var end = 0
+  for i in range(workers):
+    end += step
+    if (remainder != 0):
+      end += 1
+      remainder -= 1
+    return_vector.append(vector.slice(begin, end-1, 1))
+    begin = end
+  return return_vector
+
 func load_start(resource_list:Array)->Array:
-	var resources_in = resource_list.duplicate()
-	var out: = []
-	if can_async:
-		thread.start(self, 'threaded_load', resources_in)
-		out = yield(self, "done")
-		thread.wait_to_finish()
-	else:
-		out = regular_load(resources_in)
-	return out
-
+  var resources_in = resource_list.duplicate()
+  var out: = []
+  if can_async:
+    var n_threads = min(resources_in.size(), OS.get_processor_count())
+    var threads = []
+    for i in range(n_threads):
+      threads.append(Thread.new())
+      
+    resources_in = split_work(resources_in.size(), n_threads, resources_in)
+    for i in range(n_threads):
+      threads[i].start(self, 'threaded_load', resources_in[i])
+      
+    for i in range(n_threads):
+      out += yield(self, "done")
+      
+    for i in range(n_threads):
+      threads[i].wait_to_finish()
+  else:
+    out += regular_load(resources_in)
+  return out
+  
 func threaded_load(resources_in:Array)->void:
-	var resources_out: = []
-	
-	for res_in in resources_in:
-		mutex.lock()
-		resources_out.append(load(res_in))
-		mutex.unlock()
-	call_deferred('emit_signal', 'done', resources_out)
-
+  var resources_out: = []
+  for res_in in resources_in:
+    resources_out.append(load(res_in))
+  mutex.lock()
+  call_deferred('emit_signal', 'done', resources_out)
+  mutex.unlock()
+      
 func regular_load(resources_in:Array)->Array:
-	var resources_out: = []
-	for res_in in resources_in:
-		resources_out.append(load(res_in))
-	return resources_out
+  var resources_out: = []
+  for res_in in resources_in:
+    resources_out.append(load(res_in))
+  return resources_out

--- a/GameTemplate/addons/GameTemplate/Utility/ResourceAsyncLoader.gd
+++ b/GameTemplate/addons/GameTemplate/Utility/ResourceAsyncLoader.gd
@@ -7,7 +7,6 @@ class_name ResourceAsyncLoader  #Godot 3.2.2
 
 signal done
 
-var thread: = Thread.new()
 var mutex: = Mutex.new()
 
 var can_async:bool = OS.can_use_threads()

--- a/GameTemplate/addons/GameTemplate/Utility/ResourceAsyncLoader.gd
+++ b/GameTemplate/addons/GameTemplate/Utility/ResourceAsyncLoader.gd
@@ -40,7 +40,8 @@ func load_start(resource_list:Array)->Array:
       threads[i].start(self, 'threaded_load', resources_in[i])
       
     for i in range(n_threads):
-      out += yield(self, "done")
+	  out += yield(self, "done")
+	  mutex.unlock()
       
     for i in range(n_threads):
       threads[i].wait_to_finish()
@@ -54,7 +55,6 @@ func threaded_load(resources_in:Array)->void:
     resources_out.append(load(res_in))
   mutex.lock()
   call_deferred('emit_signal', 'done', resources_out)
-  mutex.unlock()
       
 func regular_load(resources_in:Array)->Array:
   var resources_out: = []

--- a/GameTemplate/addons/GameTemplate/Utility/ResourceAsyncLoader.gd
+++ b/GameTemplate/addons/GameTemplate/Utility/ResourceAsyncLoader.gd
@@ -12,52 +12,56 @@ var mutex: = Mutex.new()
 var can_async:bool = OS.can_use_threads()
 
 func split_work(work:int, workers:int, vector:Array)->Array:
-  var step = int(work / workers)
-  var remainder = work % workers
-  var return_vector = []
-  var begin = 0
-  var end = 0
-  for i in range(workers):
-    end += step
-    if (remainder != 0):
-      end += 1
-      remainder -= 1
-    return_vector.append(vector.slice(begin, end-1, 1))
-    begin = end
-  return return_vector
+	var step = int(work / workers)
+	var remainder = work % workers
+	var return_vector = []
+	var begin = 0
+	var end = 0
+	for i in range(workers):
+		end += step
+		if (remainder != 0):
+			end += 1
+			remainder -= 1
+		return_vector.append(vector.slice(begin, end-1, 1))
+		begin = end
+	return return_vector
 
 func load_start(resource_list:Array)->Array:
-  var resources_in = resource_list.duplicate()
-  var out: = []
-  if can_async:
-    var n_threads = min(resources_in.size(), OS.get_processor_count())
-    var threads = []
-    for i in range(n_threads):
-      threads.append(Thread.new())
-      
-    resources_in = split_work(resources_in.size(), n_threads, resources_in)
-    for i in range(n_threads):
-      threads[i].start(self, 'threaded_load', resources_in[i])
-      
-    for i in range(n_threads):
-	  out += yield(self, "done")
-	  mutex.unlock()
-      
-    for i in range(n_threads):
-      threads[i].wait_to_finish()
-  else:
-    out += regular_load(resources_in)
-  return out
+	var resources_in = resource_list.duplicate()
+	var out: = []
+	if can_async:
+		var n_threads = min(resources_in.size(), OS.get_processor_count())
+		var threads = []
+		var sync_out = {}
+		for i in range(n_threads):
+			threads.append(Thread.new())
+
+		resources_in = split_work(resources_in.size(), n_threads, resources_in)
+		for i in range(n_threads):
+			threads[i].start(self, 'threaded_load', [resources_in[i], i])
+			
+		for i in range(n_threads):
+			var temp = yield(self, "done")
+			sync_out[temp[1]] = temp[0]
+			mutex.unlock()
+			
+		for i in range(n_threads):
+			threads[i].wait_to_finish()
+			out += sync_out[i]
+		
+	else:
+		out += regular_load(resources_in)
+	return out
   
-func threaded_load(resources_in:Array)->void:
-  var resources_out: = []
-  for res_in in resources_in:
-    resources_out.append(load(res_in))
-  mutex.lock()
-  call_deferred('emit_signal', 'done', resources_out)
-      
+func threaded_load(resources:Array)->void:
+	var resources_out: = []
+	for res_in in resources[0]:
+		resources_out.append(load(res_in))
+	mutex.lock()
+	call_deferred('emit_signal', 'done', resources_out, resources[1])
+	  
 func regular_load(resources_in:Array)->Array:
-  var resources_out: = []
-  for res_in in resources_in:
-    resources_out.append(load(res_in))
-  return resources_out
+	var resources_out: = []
+	for res_in in resources_in:
+		resources_out.append(load(res_in))
+	return resources_out


### PR DESCRIPTION
Hello,

I have been using your template a long time and I notice this week that your async load isn't working appropriately.
First of all the function creates only one thread and blocks the load instruction with a mutex, this haven't anything differente between the sequencial and parallel form.

This pull request isn't the best one and you should improve it. This creates a lot of threads (acctualy or the numbers of threads that the systems support or the numbers os scenes to load) and remove the mutex on the resources_out array.

**Sync_out is used to syncronize the output, this allow us to return the output in the same order that we receive the input.