### PR TITLE
prototype timeline

### DIFF
--- a/GameTemplate/Garbage/TimedNode.gd
+++ b/GameTemplate/Garbage/TimedNode.gd
@@ -1,0 +1,21 @@
+extends RigidBody2D
+
+func get_state():
+    var physics_state = Physics2DServer.body_get_direct_state(get_rid())
+
+    return {
+        "transform": physics_state.transform,
+        "linear_velocity": physics_state.linear_velocity,
+        "angular_velocity": physics_state.angular_velocity
+    }
+
+func apply_state(state):
+    var physics_state = Physics2DServer.body_get_direct_state(get_rid())
+
+    global_transform = state.transform
+    physics_state.transform = state.transform
+    physics_state.linear_velocity = state.linear_velocity
+    physics_state.angular_velocity = state.angular_velocity
+
+    physics_state.integrate_forces()
+

--- a/GameTemplate/Garbage/TimedRigidBody.tscn
+++ b/GameTemplate/Garbage/TimedRigidBody.tscn
@@ -1,0 +1,18 @@
+[gd_scene load_steps=4 format=2]
+
+[ext_resource path="res://icon.png" type="Texture" id=1]
+[ext_resource path="res://Garbage/TimedNode.gd" type="Script" id=2]
+
+[sub_resource type="CircleShape2D" id=1]
+radius = 32.0207
+
+[node name="TimedNode" type="RigidBody2D" groups=[
+"timed",
+]]
+script = ExtResource( 2 )
+
+[node name="icon" type="Sprite" parent="."]
+texture = ExtResource( 1 )
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+shape = SubResource( 1 )

--- a/GameTemplate/Garbage/TimelineTest.tscn
+++ b/GameTemplate/Garbage/TimelineTest.tscn
@@ -1,0 +1,36 @@
+[gd_scene load_steps=4 format=2]
+
+[ext_resource path="res://Garbage/TimedRigidBody.tscn" type="PackedScene" id=1]
+
+[sub_resource type="PhysicsMaterial" id=2]
+bounce = 0.9
+
+[sub_resource type="RectangleShape2D" id=1]
+extents = Vector2( 188.717, 12.1217 )
+
+[node name="Node2D" type="Node2D"]
+
+[node name="TimedNode" parent="." instance=ExtResource( 1 )]
+
+[node name="TimedNode3" parent="." instance=ExtResource( 1 )]
+position = Vector2( 29.665, -119.19 )
+rotation = -0.848715
+scale = Vector2( 2, 2 )
+linear_velocity = Vector2( 0, -10 )
+
+[node name="TimedNode4" parent="." instance=ExtResource( 1 )]
+position = Vector2( 69.3948, -32.8434 )
+
+[node name="TimedNode2" parent="." instance=ExtResource( 1 )]
+position = Vector2( 35.2271, 70.7191 )
+physics_material_override = SubResource( 2 )
+
+[node name="StaticBody2D" type="StaticBody2D" parent="."]
+position = Vector2( 0.794594, 121.308 )
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="StaticBody2D"]
+shape = SubResource( 1 )
+
+[node name="Camera2D" type="Camera2D" parent="."]
+current = true
+zoom = Vector2( 2, 2 )

--- a/GameTemplate/Globals/Timeline.gd
+++ b/GameTemplate/Globals/Timeline.gd
@@ -1,0 +1,66 @@
+extends Node
+
+var keyframes:Dictionary = {}
+var cached_frames:Array = []
+var current_frame:int = 0
+
+func _ready():
+	pause_mode = PAUSE_MODE_PROCESS
+
+func advance_frame():
+	# Get all time-managed nodes
+	var timed_nodes = get_tree().get_nodes_in_group("timed")
+
+	# This is a new frame
+	if cached_frames.size() <= current_frame:
+		# Instantiate new frame container
+		var current_cached_state
+		current_cached_state = {}
+		cached_frames.append(current_cached_state)
+
+		for node in timed_nodes:
+			if node.has_method("get_state"):
+				var path = node.get_path()
+				current_cached_state[path] = node.get_state()
+	
+	current_frame += 1
+
+func cut_cached_frames(frame:int, clear_keyframes:bool = false):
+	# remove cached frames after {frame}
+	cached_frames.resize(frame+1)
+	if clear_keyframes:
+		for keyframe_frame in keyframes:
+			if keyframe_frame > frame:
+				# Maybe use erase rather than just nullifying
+				# B: Prevent hashmap size adjustment
+				keyframes[keyframe_frame] = null
+
+func seek(frame:int):
+	var current_cached_state = cached_frames[frame]
+	if current_cached_state:
+		for node_path in current_cached_state:
+			var node = get_node(node_path)
+			var state = current_cached_state[node_path]
+			if node.has_method("apply_state"):
+				node.apply_state(state)
+	current_frame = frame
+
+func _physics_process(delta):
+	if cached_frames.size() < 253:
+		get_tree().paused = false
+		advance_frame()
+	else:
+		get_tree().paused = true
+
+func _unhandled_input(event):
+	var seek_speed = 10
+	if event.is_action_pressed("ui_left", true):
+		yield(get_tree(), "physics_frame")
+		seek(max(current_frame-seek_speed, 0))
+	
+	if event.is_action_pressed("ui_right", true):
+		yield(get_tree(), "physics_frame")
+		seek(min(current_frame+seek_speed, cached_frames.size()-1))
+
+	if event.is_action_pressed("ui_accept"):
+		cut_cached_frames(current_frame)

--- a/GameTemplate/project.godot
+++ b/GameTemplate/project.godot
@@ -47,6 +47,7 @@ MenuEvent="*res://addons/GameTemplate/Autoload/MenuEvent.gd"
 Music="*res://addons/GameTemplate/Autoload/Music.tscn"
 SfxManager="*res://addons/GameTemplate/Autoload/SfxManager.gd"
 HtmlFocus="*res://addons/GameTemplate/Autoload/HtmlFocus.tscn"
+Timeline="*res://Globals/Timeline.gd"
 
 [debug]
 
@@ -177,7 +178,6 @@ translations=PoolStringArray(  )
 
 [rendering]
 
-quality/driver/driver_name="GLES2"
 vram_compression/import_etc=true
 vram_compression/import_etc2=false
 environment/default_environment="res://default_env.tres"


### PR DESCRIPTION
- I found the logic for how the pause function works, and the Physics2DServer has a `set_active` function which I use instead of the tree pausing so we only pause physics.
- `apply_state` now takes the previous state, and the delta between frames (0-1) so interpolation is possible
- Instead of having timeline as a singleton I figured because of the way we programmed it, it could actually be a node added in each level so each level could have it's own configurations for how the timeline will work
  - added a max_time, if it's greater than 0 it'll stop playing after that. This will also need some work to probably pause in intervals if max time isn't enabled?
 - playing can be set to false for a level to make it pause right away
