### PR TITLE
Disable pause menu before transition

### DIFF
--- a/GameTemplate/Levels/Level.gd
+++ b/GameTemplate/Levels/Level.gd
@@ -7,6 +7,7 @@ func _ready()->void:
 	PauseMenu.can_show = true
 
 func _on_Button_pressed()->void:
+	PauseMenu.can_show = false
 	Game.emit_signal("ChangeScene", Next_Scene)
 
 func _exit_tree()->void:


### PR DESCRIPTION
This will disable the pause menu exactly when you hit "Go Back" in the game. The pause menu will continue to work when joining a new game from the _ready() function.