### PR TITLE
renamed show to show_menu since show/hide is implemented in CanvasLayer

### DIFF
--- a/GameTemplate/addons/GameTemplate/Autoload/MenuEvent.gd
+++ b/GameTemplate/addons/GameTemplate/Autoload/MenuEvent.gd
@@ -45,8 +45,8 @@ func _input(event)->void:												#used to get back in menus
 		elif Options:
 			set_options(false)
 			if PauseMenu.can_show:
-				PauseMenu.show(true)
+				PauseMenu.show_menu(true)
 		elif Paused:
-			PauseMenu.show(false)
+			PauseMenu.show_menu(false)
 		elif PauseMenu.can_show:
-			PauseMenu.show(true)
+			PauseMenu.show_menu(true)

--- a/GameTemplate/addons/GameTemplate/Autoload/PauseMenu.tscn
+++ b/GameTemplate/addons/GameTemplate/Autoload/PauseMenu.tscn
@@ -28,7 +28,7 @@ func _ready()->void:
 	retranslate()
 	
 
-func show(value:bool)->void:
+func show_menu(value:bool)->void:
 	if !can_show:
 		return
 	MenuEvent.Paused = value
@@ -39,18 +39,18 @@ func show(value:bool)->void:
 
 func _on_Resume_pressed()->void:
 	Game.emit_signal(\"Resume\")
-	show(false)
+	show_menu(false)
 
 func _on_Restart_pressed()->void:
 	Game.emit_signal(\"Restart\")
-	show(false)
+	show_menu(false)
 
 func _on_Options_pressed()->void:
 	MenuEvent.Options = true
 
 func _on_MainMenu_pressed()->void:
 	Game.emit_signal(\"ChangeScene\", MainMenu)
-	show(false)
+	show_menu(false)
 	PauseMenu.can_show = false
 
 func _on_Exit_pressed()->void:


### PR DESCRIPTION
Upon loading the scene I was presented with an error when calling show on the PauseMenu. On the stable release (v3.5.1.stable.official [6fed1ffa3]) CanvasLayer has show/hide implemented.

Ideally I think it would be better to implement those calls in the PauseMenu, but this is an easy fix for now.