### PR TITLE
Update for Godot 4.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,22 @@ mono_crash.*.json
 .directory
 *~
 *.import
+
+# macOS-specific ignores
+.DS_Store
+
+# Godot 4+ specific ignores
+.godot/
+
+# Godot-specific ignores
+.import/
+export.cfg
+export_presets.cfg
+
+# Imported translations (automatically generated from CSV files)
+*.translation
+
+# Mono-specific ignores
+.mono/
+data_*/
+mono_crash.*.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,18 +1,3 @@
-
-# Godot-specific ignores
-.import/
-export.cfg
-export_presets.cfg
-debug.log
-**/*.import
-# Imported translations (automatically generated from CSV files)
-*.translation
-
-# Mono-specific ignores
-.mono/
-data_*/
-mono_crash.*.json
-
 # System/tool-specific ignores
 .directory
 *~
@@ -37,4 +22,5 @@ export_presets.cfg
 data_*/
 mono_crash.*.json
 
-builds/
+build/
+android/

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ export_presets.cfg
 .mono/
 data_*/
 mono_crash.*.json
+
+builds/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,62 @@
+image: barichello/gcodot-ci:4.2.0
+
+variables:
+  EXPORT_NAME: my-project-name
+
+stages:
+  - export
+  - deploy
+
+windows:
+  stage: export
+  script:
+    - mkdir -v -p build/windows
+    - godot -v --export "Windows Desktop" ./build/windows/$EXPORT_NAME.exe
+  artifacts:
+    name: $EXPORT_NAME-$CI_JOB_NAME
+    paths:
+      - build/windows
+
+linux:
+  stage: export
+  script:
+    - mkdir -v -p build/linux
+    - godot -v --export "Linux/X11" ./build/linux/$EXPORT_NAME.x86_64
+  artifacts:
+    name: $EXPORT_NAME-$CI_JOB_NAME
+    paths:
+      - build/linux
+
+macosx:
+  stage: export
+  script:
+    - mkdir -v -p build/macosx
+    - godot -v --export "Mac OSX" ./build/macosx/$EXPORT_NAME.zip
+    - (cd ./build/macosx && unzip -a $EXPORT_NAME.zip && rm $EXPORT_NAME.zip)
+  artifacts:
+    name: $EXPORT_NAME-$CI_JOB_NAME
+    paths:
+      - build/macosx
+
+web:
+  stage: export
+  script:
+    - mkdir -v -p build/web
+    - godot -v --export "HTML5" ./build/web/index.html
+  artifacts:
+    name: $EXPORT_NAME-$CI_JOB_NAME
+    paths:
+      - build/web
+
+pages:
+  stage: deploy
+  dependencies:
+    - web
+  script:
+    - rm -rf public
+    - cp -r build/web public
+  artifacts:
+    paths:
+      - public
+  only:
+   - develop

--- a/GameTemplate/Assets/Fonts/pixellocale_8.tres
+++ b/GameTemplate/Assets/Fonts/pixellocale_8.tres
@@ -1,6 +1,6 @@
-[gd_resource type="DynamicFont" load_steps=2 format=2]
+[gd_resource type="FontFile" load_steps=2 format=2]
 
-[ext_resource path="res://Assets/Fonts/pixellocale-v-1-4.ttf" type="DynamicFontData" id=1]
+[ext_resource path="res://Assets/Fonts/pixellocale-v-1-4.ttf" type="FontFile" id=1]
 
 [resource]
 size = 8

--- a/GameTemplate/Assets/Sounds/TestBeep.wav.import
+++ b/GameTemplate/Assets/Sounds/TestBeep.wav.import
@@ -1,13 +1,14 @@
 [remap]
 
 importer="wav"
-type="AudioStreamSample"
-path="res://.import/TestBeep.wav-d3be0e3d1ff487c414537f0fa6dc011c.sample"
+type="AudioStreamWAV"
+uid="uid://ctn7x3kcgkey6"
+path="res://.godot/imported/TestBeep.wav-d3be0e3d1ff487c414537f0fa6dc011c.sample"
 
 [deps]
 
 source_file="res://Assets/Sounds/TestBeep.wav"
-dest_files=[ "res://.import/TestBeep.wav-d3be0e3d1ff487c414537f0fa6dc011c.sample" ]
+dest_files=["res://.godot/imported/TestBeep.wav-d3be0e3d1ff487c414537f0fa6dc011c.sample"]
 
 [params]
 
@@ -17,5 +18,7 @@ force/max_rate=false
 force/max_rate_hz=44100
 edit/trim=true
 edit/normalize=true
-edit/loop=false
+edit/loop_mode=0
+edit/loop_begin=0
+edit/loop_end=-1
 compress/mode=0

--- a/GameTemplate/Levels/Level.gd
+++ b/GameTemplate/Levels/Level.gd
@@ -1,6 +1,6 @@
 extends Node2D
 
-export (String, FILE, "*.tscn") var Next_Scene: String
+@export var Next_Scene: String # (String, FILE, "*.tscn")
 
 func _ready()->void:
 	Hud.visible = true

--- a/GameTemplate/Levels/TestScene.tscn
+++ b/GameTemplate/Levels/TestScene.tscn
@@ -1,72 +1,9 @@
-[gd_scene load_steps=6 format=3 uid="uid://c25bqavugtpfj"]
+[gd_scene load_steps=5 format=3 uid="uid://c25bqavugtpfj"]
 
 [ext_resource type="Script" path="res://Levels/Level.gd" id="1"]
-[ext_resource type="FontFile" uid="uid://cj1os0is1qn2h" path="res://addons/GameTemplate/Assets/Fonts/pixellocale-v-1-4.ttf" id="2_xvw7o"]
-[ext_resource type="Texture2D" uid="uid://cb0tbpriomwqd" path="res://icon.png" id="3"]
+[ext_resource type="FontFile" uid="uid://c5gjw5i0akjja" path="res://Assets/Fonts/pixellocale-v-1-4.ttf" id="2_usos8"]
+[ext_resource type="Texture2D" uid="uid://ctghwtp0t782j" path="res://icon.png" id="3"]
 [ext_resource type="Script" path="res://Levels/player.gd" id="4"]
-
-[sub_resource type="FontFile" id="FontFile_4wxgj"]
-fallbacks = Array[Font]([ExtResource("2_xvw7o")])
-cache/0/16/0/ascent = 0.0
-cache/0/16/0/descent = 0.0
-cache/0/16/0/underline_position = 0.0
-cache/0/16/0/underline_thickness = 0.0
-cache/0/16/0/scale = 1.0
-cache/0/50/0/ascent = 0.0
-cache/0/50/0/descent = 0.0
-cache/0/50/0/underline_position = 0.0
-cache/0/50/0/underline_thickness = 0.0
-cache/0/50/0/scale = 1.0
-cache/0/2/0/ascent = 0.0
-cache/0/2/0/descent = 0.0
-cache/0/2/0/underline_position = 0.0
-cache/0/2/0/underline_thickness = 0.0
-cache/0/2/0/scale = 1.0
-cache/0/3/0/ascent = 0.0
-cache/0/3/0/descent = 0.0
-cache/0/3/0/underline_position = 0.0
-cache/0/3/0/underline_thickness = 0.0
-cache/0/3/0/scale = 1.0
-cache/0/4/0/ascent = 0.0
-cache/0/4/0/descent = 0.0
-cache/0/4/0/underline_position = 0.0
-cache/0/4/0/underline_thickness = 0.0
-cache/0/4/0/scale = 1.0
-cache/0/5/0/ascent = 0.0
-cache/0/5/0/descent = 0.0
-cache/0/5/0/underline_position = 0.0
-cache/0/5/0/underline_thickness = 0.0
-cache/0/5/0/scale = 1.0
-cache/0/6/0/ascent = 0.0
-cache/0/6/0/descent = 0.0
-cache/0/6/0/underline_position = 0.0
-cache/0/6/0/underline_thickness = 0.0
-cache/0/6/0/scale = 1.0
-cache/0/7/0/ascent = 0.0
-cache/0/7/0/descent = 0.0
-cache/0/7/0/underline_position = 0.0
-cache/0/7/0/underline_thickness = 0.0
-cache/0/7/0/scale = 1.0
-cache/0/8/0/ascent = 0.0
-cache/0/8/0/descent = 0.0
-cache/0/8/0/underline_position = 0.0
-cache/0/8/0/underline_thickness = 0.0
-cache/0/8/0/scale = 1.0
-cache/0/9/0/ascent = 0.0
-cache/0/9/0/descent = 0.0
-cache/0/9/0/underline_position = 0.0
-cache/0/9/0/underline_thickness = 0.0
-cache/0/9/0/scale = 1.0
-cache/0/10/0/ascent = 0.0
-cache/0/10/0/descent = 0.0
-cache/0/10/0/underline_position = 0.0
-cache/0/10/0/underline_thickness = 0.0
-cache/0/10/0/scale = 1.0
-cache/0/15/0/ascent = 0.0
-cache/0/15/0/descent = 0.0
-cache/0/15/0/underline_position = 0.0
-cache/0/15/0/underline_thickness = 0.0
-cache/0/15/0/scale = 1.0
 
 [node name="Level" type="Node2D"]
 script = ExtResource("1")
@@ -90,7 +27,8 @@ offset_left = -53.0
 offset_top = -21.0
 offset_right = 55.0
 offset_bottom = 19.0
-theme_override_fonts/font = SubResource("FontFile_4wxgj")
+theme_override_fonts/font = ExtResource("2_usos8")
+theme_override_font_sizes/font_size = 18
 text = "GO BACK"
 
 [node name="Sprite2D" type="Sprite2D" parent="CanvasLayer"]

--- a/GameTemplate/Levels/TestScene.tscn
+++ b/GameTemplate/Levels/TestScene.tscn
@@ -1,40 +1,102 @@
-[gd_scene load_steps=5 format=2]
+[gd_scene load_steps=6 format=3 uid="uid://c25bqavugtpfj"]
 
-[ext_resource path="res://Levels/Level.gd" type="Script" id=1]
-[ext_resource path="res://addons/GameTemplate/Assets/Fonts/pixellocale_16.tres" type="DynamicFont" id=2]
-[ext_resource path="res://icon.png" type="Texture" id=3]
-[ext_resource path="res://Levels/player.gd" type="Script" id=4]
+[ext_resource type="Script" path="res://Levels/Level.gd" id="1"]
+[ext_resource type="FontFile" uid="uid://cj1os0is1qn2h" path="res://addons/GameTemplate/Assets/Fonts/pixellocale-v-1-4.ttf" id="2_xvw7o"]
+[ext_resource type="Texture2D" uid="uid://cb0tbpriomwqd" path="res://icon.png" id="3"]
+[ext_resource type="Script" path="res://Levels/player.gd" id="4"]
+
+[sub_resource type="FontFile" id="FontFile_4wxgj"]
+fallbacks = Array[Font]([ExtResource("2_xvw7o")])
+cache/0/16/0/ascent = 0.0
+cache/0/16/0/descent = 0.0
+cache/0/16/0/underline_position = 0.0
+cache/0/16/0/underline_thickness = 0.0
+cache/0/16/0/scale = 1.0
+cache/0/50/0/ascent = 0.0
+cache/0/50/0/descent = 0.0
+cache/0/50/0/underline_position = 0.0
+cache/0/50/0/underline_thickness = 0.0
+cache/0/50/0/scale = 1.0
+cache/0/2/0/ascent = 0.0
+cache/0/2/0/descent = 0.0
+cache/0/2/0/underline_position = 0.0
+cache/0/2/0/underline_thickness = 0.0
+cache/0/2/0/scale = 1.0
+cache/0/3/0/ascent = 0.0
+cache/0/3/0/descent = 0.0
+cache/0/3/0/underline_position = 0.0
+cache/0/3/0/underline_thickness = 0.0
+cache/0/3/0/scale = 1.0
+cache/0/4/0/ascent = 0.0
+cache/0/4/0/descent = 0.0
+cache/0/4/0/underline_position = 0.0
+cache/0/4/0/underline_thickness = 0.0
+cache/0/4/0/scale = 1.0
+cache/0/5/0/ascent = 0.0
+cache/0/5/0/descent = 0.0
+cache/0/5/0/underline_position = 0.0
+cache/0/5/0/underline_thickness = 0.0
+cache/0/5/0/scale = 1.0
+cache/0/6/0/ascent = 0.0
+cache/0/6/0/descent = 0.0
+cache/0/6/0/underline_position = 0.0
+cache/0/6/0/underline_thickness = 0.0
+cache/0/6/0/scale = 1.0
+cache/0/7/0/ascent = 0.0
+cache/0/7/0/descent = 0.0
+cache/0/7/0/underline_position = 0.0
+cache/0/7/0/underline_thickness = 0.0
+cache/0/7/0/scale = 1.0
+cache/0/8/0/ascent = 0.0
+cache/0/8/0/descent = 0.0
+cache/0/8/0/underline_position = 0.0
+cache/0/8/0/underline_thickness = 0.0
+cache/0/8/0/scale = 1.0
+cache/0/9/0/ascent = 0.0
+cache/0/9/0/descent = 0.0
+cache/0/9/0/underline_position = 0.0
+cache/0/9/0/underline_thickness = 0.0
+cache/0/9/0/scale = 1.0
+cache/0/10/0/ascent = 0.0
+cache/0/10/0/descent = 0.0
+cache/0/10/0/underline_position = 0.0
+cache/0/10/0/underline_thickness = 0.0
+cache/0/10/0/scale = 1.0
+cache/0/15/0/ascent = 0.0
+cache/0/15/0/descent = 0.0
+cache/0/15/0/underline_position = 0.0
+cache/0/15/0/underline_thickness = 0.0
+cache/0/15/0/scale = 1.0
 
 [node name="Level" type="Node2D"]
-script = ExtResource( 1 )
+script = ExtResource("1")
 Next_Scene = "res://MainMenu/MainMenu.tscn"
 
 [node name="CanvasLayer" type="CanvasLayer" parent="."]
 
 [node name="ColorRect" type="ColorRect" parent="CanvasLayer"]
+anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
-color = Color( 0.662745, 1, 0.537255, 1 )
+color = Color(0.662745, 1, 0.537255, 1)
 
 [node name="Button" type="Button" parent="CanvasLayer"]
+anchors_preset = 8
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
 anchor_bottom = 0.5
-margin_left = -53.0
-margin_top = -21.0
-margin_right = 55.0
-margin_bottom = 19.0
-custom_fonts/font = ExtResource( 2 )
+offset_left = -53.0
+offset_top = -21.0
+offset_right = 55.0
+offset_bottom = 19.0
+theme_override_fonts/font = SubResource("FontFile_4wxgj")
 text = "GO BACK"
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
-[node name="Sprite" type="Sprite" parent="CanvasLayer"]
-position = Vector2( 156.129, 131.574 )
-scale = Vector2( 0.5, 0.5 )
-texture = ExtResource( 3 )
-script = ExtResource( 4 )
+[node name="Sprite2D" type="Sprite2D" parent="CanvasLayer"]
+position = Vector2(156.129, 131.574)
+scale = Vector2(0.5, 0.5)
+texture = ExtResource("3")
+script = ExtResource("4")
 
 [connection signal="pressed" from="CanvasLayer/Button" to="." method="_on_Button_pressed"]

--- a/GameTemplate/Levels/player.gd
+++ b/GameTemplate/Levels/player.gd
@@ -1,4 +1,4 @@
-extends Sprite
+extends Sprite2D
 
 var speed = 2 * 60
 

--- a/GameTemplate/MainMenu/DefaultButton.tscn
+++ b/GameTemplate/MainMenu/DefaultButton.tscn
@@ -1,19 +1,18 @@
-[gd_scene load_steps=6 format=2]
+[gd_scene load_steps=6 format=3 uid="uid://px4rxhrebsso"]
 
-[ext_resource path="res://Assets/Fonts/pixellocale_8.tres" type="DynamicFont" id=1]
+[ext_resource type="FontFile" path="res://Assets/Fonts/pixellocale_8.tres" id="1"]
 
-
-[sub_resource type="StyleBoxFlat" id=1]
+[sub_resource type="StyleBoxFlat" id="3"]
 content_margin_left = 2.0
-content_margin_right = 2.0
 content_margin_top = 0.0
+content_margin_right = 2.0
 content_margin_bottom = 1.0
-bg_color = Color( 0.0705882, 0.305882, 0.537255, 1 )
+bg_color = Color(0.14902, 0.168627, 0.266667, 0)
 border_width_left = 1
 border_width_top = 1
 border_width_right = 1
 border_width_bottom = 1
-border_color = Color( 1, 1, 1, 0 )
+border_color = Color(0.0705882, 0.305882, 0.537255, 1)
 corner_radius_top_left = 2
 corner_radius_top_right = 2
 corner_radius_bottom_right = 2
@@ -24,17 +23,34 @@ expand_margin_right = 2.0
 expand_margin_bottom = 1.0
 anti_aliasing = false
 
-[sub_resource type="StyleBoxFlat" id=2]
+[sub_resource type="StyleBoxFlat" id="4"]
 content_margin_left = 2.0
-content_margin_right = 2.0
 content_margin_top = 0.0
+content_margin_right = 2.0
 content_margin_bottom = 1.0
-bg_color = Color( 0.227451, 0.266667, 0.4, 1 )
+bg_color = Color(0.14902, 0.168627, 0.266667, 1)
 border_width_left = 1
 border_width_top = 1
 border_width_right = 1
 border_width_bottom = 1
-border_color = Color( 1, 1, 1, 0 )
+border_color = Color(1, 1, 1, 0)
+corner_detail = 1
+expand_margin_left = 2.0
+expand_margin_right = 2.0
+expand_margin_bottom = 1.0
+anti_aliasing = false
+
+[sub_resource type="StyleBoxFlat" id="1"]
+content_margin_left = 2.0
+content_margin_top = 0.0
+content_margin_right = 2.0
+content_margin_bottom = 1.0
+bg_color = Color(0.0705882, 0.305882, 0.537255, 1)
+border_width_left = 1
+border_width_top = 1
+border_width_right = 1
+border_width_bottom = 1
+border_color = Color(1, 1, 1, 0)
 corner_radius_top_left = 2
 corner_radius_top_right = 2
 corner_radius_bottom_right = 2
@@ -45,38 +61,21 @@ expand_margin_right = 2.0
 expand_margin_bottom = 1.0
 anti_aliasing = false
 
-[sub_resource type="StyleBoxFlat" id=3]
+[sub_resource type="StyleBoxFlat" id="2"]
 content_margin_left = 2.0
-content_margin_right = 2.0
 content_margin_top = 0.0
+content_margin_right = 2.0
 content_margin_bottom = 1.0
-bg_color = Color( 0.14902, 0.168627, 0.266667, 0 )
+bg_color = Color(0.227451, 0.266667, 0.4, 1)
 border_width_left = 1
 border_width_top = 1
 border_width_right = 1
 border_width_bottom = 1
-border_color = Color( 0.0705882, 0.305882, 0.537255, 1 )
+border_color = Color(1, 1, 1, 0)
 corner_radius_top_left = 2
 corner_radius_top_right = 2
 corner_radius_bottom_right = 2
 corner_radius_bottom_left = 2
-corner_detail = 1
-expand_margin_left = 2.0
-expand_margin_right = 2.0
-expand_margin_bottom = 1.0
-anti_aliasing = false
-
-[sub_resource type="StyleBoxFlat" id=4]
-content_margin_left = 2.0
-content_margin_right = 2.0
-content_margin_top = 0.0
-content_margin_bottom = 1.0
-bg_color = Color( 0.14902, 0.168627, 0.266667, 1 )
-border_width_left = 1
-border_width_top = 1
-border_width_right = 1
-border_width_bottom = 1
-border_color = Color( 1, 1, 1, 0 )
 corner_detail = 1
 expand_margin_left = 2.0
 expand_margin_right = 2.0
@@ -84,17 +83,14 @@ expand_margin_bottom = 1.0
 anti_aliasing = false
 
 [node name="DefaultButton" type="Button"]
-margin_right = 36.0
-margin_bottom = 15.0
+offset_right = 36.0
+offset_bottom = 15.0
 size_flags_horizontal = 3
 size_flags_vertical = 4
-custom_styles/hover = SubResource( 1 )
-custom_styles/pressed = SubResource( 2 )
-custom_styles/focus = SubResource( 3 )
-custom_styles/disabled = SubResource( 4 )
-custom_styles/normal = SubResource( 4 )
-custom_fonts/font = ExtResource( 1 )
+theme_override_fonts/font = ExtResource("1")
+theme_override_styles/focus = SubResource("3")
+theme_override_styles/disabled = SubResource("4")
+theme_override_styles/hover = SubResource("1")
+theme_override_styles/pressed = SubResource("2")
+theme_override_styles/normal = SubResource("4")
 text = "Button"
-__meta__ = {
-"_edit_use_anchors_": false
-}

--- a/GameTemplate/MainMenu/MainMenu.gd
+++ b/GameTemplate/MainMenu/MainMenu.gd
@@ -6,7 +6,7 @@ extends CanvasLayer
 func _ready()->void:
 	get_tree().get_nodes_in_group("MainMenu")[0].grab_focus()
 	MenuEvent.connect("OptionsSignal", on_options)
-	if OS.get_name() == "HTML5":
+	if OS.has_feature('web'):
 		exit.visible = false
 	#Localization
 	SettingsLanguage.connect("ReTranslate", retranslate)

--- a/GameTemplate/MainMenu/MainMenu.gd
+++ b/GameTemplate/MainMenu/MainMenu.gd
@@ -1,19 +1,19 @@
 extends CanvasLayer
 
-export (String, FILE, "*.tscn") var First_Level: String
+@export var First_Level: String # (String, FILE, "*.tscn")
 
 func _ready()->void:
-	get_tree().get_nodes_in_group("MainMenu")[0].grab_focus()					#Godot doesn't have buttons auto grab_focus when noone has focus
-	MenuEvent.connect("Options", self, "on_options")
+	get_tree().get_nodes_in_group("MainMenu")[0].grab_focus()
+	MenuEvent.connect("OptionsSignal", on_options)
 	
 	if OS.get_name() == "HTML5":
 		$"BG/MarginContainer/VBoxMain/HBoxContainer/ButtonContainer/Exit".visible = false
 	#Localization
-	SettingsLanguage.connect("ReTranslate", self, "retranslate")
+	SettingsLanguage.connect("ReTranslate", retranslate)
 	retranslate()
 
 func on_options(value:bool)->void:
-	if !value && !MenuEvent.Paused:
+	if !value && !MenuEvent.Paused_val:
 		get_tree().get_nodes_in_group("MainMenu")[0].grab_focus()
 
 func _on_NewGame_pressed()->void:
@@ -21,13 +21,13 @@ func _on_NewGame_pressed()->void:
 	Game.emit_signal("ChangeScene", First_Level)
 
 func _on_Options_pressed()->void:
-	MenuEvent.Options = true
+	MenuEvent.Options_val = true
 
 func _on_Exit_pressed()->void:
 	Game.emit_signal("Exit")
 
 #Localization
 func retranslate()->void:
-	find_node("NewGame").text = tr("NEW_GAME")
-	find_node("Options").text = tr("OPTIONS")
-	find_node("Exit").text = tr("EXIT")
+	find_child("NewGame").text = tr("NEW_GAME")
+	find_child("Options").text = tr("OPTIONS")
+	find_child("Exit").text = tr("EXIT")

--- a/GameTemplate/MainMenu/MainMenu.gd
+++ b/GameTemplate/MainMenu/MainMenu.gd
@@ -1,16 +1,17 @@
 extends CanvasLayer
 
 @export var First_Level: String # (String, FILE, "*.tscn")
+@onready var exit: Button = $BG/MarginContainer/VBoxMain/HBoxContainer/ButtonContainer/Exit
 
 func _ready()->void:
 	get_tree().get_nodes_in_group("MainMenu")[0].grab_focus()
 	MenuEvent.connect("OptionsSignal", on_options)
-	
 	if OS.get_name() == "HTML5":
-		$"BG/MarginContainer/VBoxMain/HBoxContainer/ButtonContainer/Exit".visible = false
+		exit.visible = false
 	#Localization
 	SettingsLanguage.connect("ReTranslate", retranslate)
 	retranslate()
+	
 
 func on_options(value:bool)->void:
 	if !value && !MenuEvent.Paused_val:

--- a/GameTemplate/MainMenu/MainMenu.tscn
+++ b/GameTemplate/MainMenu/MainMenu.tscn
@@ -1,88 +1,73 @@
-[gd_scene load_steps=5 format=2]
+[gd_scene load_steps=5 format=3 uid="uid://dcjkkkgaaqbqs"]
 
-[ext_resource path="res://addons/GameTemplate/GUI/Buttons/DefaultButton.tscn" type="PackedScene" id=1]
-[ext_resource path="res://icon.png" type="Texture" id=2]
-[ext_resource path="res://MainMenu/MainMenu.gd" type="Script" id=3]
+[ext_resource type="PackedScene" uid="uid://dp81qs74tu3ba" path="res://addons/GameTemplate/GUI/Buttons/DefaultButton.tscn" id="1"]
+[ext_resource type="Texture2D" uid="uid://cb0tbpriomwqd" path="res://icon.png" id="2"]
+[ext_resource type="Script" path="res://MainMenu/MainMenu.gd" id="3"]
 
-[sub_resource type="StyleBoxFlat" id=1]
-bg_color = Color( 0.0941176, 0.0784314, 0.145098, 1 )
+[sub_resource type="StyleBoxFlat" id="1"]
+bg_color = Color(0.0941176, 0.0784314, 0.145098, 1)
 
 [node name="MainMenu" type="CanvasLayer"]
 layer = 0
-script = ExtResource( 3 )
+script = ExtResource("3")
 First_Level = "res://Levels/TestScene.tscn"
 
 [node name="BG" type="Panel" parent="."]
-pause_mode = 2
+process_mode = 3
+anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
-custom_styles/panel = SubResource( 1 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_styles/panel = SubResource("1")
 
 [node name="MarginContainer" type="MarginContainer" parent="BG"]
+layout_mode = 1
+anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
-custom_constants/margin_right = 16
-custom_constants/margin_top = 16
-custom_constants/margin_left = 16
-custom_constants/margin_bottom = 16
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/margin_left = 16
+theme_override_constants/margin_top = 16
+theme_override_constants/margin_right = 16
+theme_override_constants/margin_bottom = 16
 
 [node name="VBoxMain" type="VBoxContainer" parent="BG/MarginContainer"]
-margin_left = 16.0
-margin_top = 16.0
-margin_right = 304.0
-margin_bottom = 164.0
+layout_mode = 2
 size_flags_vertical = 3
-
-[node name="CenterLogo" type="CenterContainer" parent="BG/MarginContainer/VBoxMain"]
-margin_right = 288.0
-margin_bottom = 64.0
-
-[node name="Logo" type="TextureRect" parent="BG/MarginContainer/VBoxMain/CenterLogo"]
-margin_left = 112.0
-margin_right = 176.0
-margin_bottom = 64.0
-texture = ExtResource( 2 )
 
 [node name="HBoxContainer" type="HBoxContainer" parent="BG/MarginContainer/VBoxMain"]
-margin_top = 68.0
-margin_right = 288.0
-margin_bottom = 148.0
+layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
+alignment = 1
 
 [node name="ButtonContainer" type="VBoxContainer" parent="BG/MarginContainer/VBoxMain/HBoxContainer"]
-margin_right = 51.0
-margin_bottom = 80.0
-size_flags_vertical = 3
-custom_constants/separation = 1
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 6
+theme_override_constants/separation = 1
 
-[node name="NewGame" parent="BG/MarginContainer/VBoxMain/HBoxContainer/ButtonContainer" groups=[
-"MainMenu",
-] instance=ExtResource( 1 )]
-margin_right = 51.0
+[node name="NewGame" parent="BG/MarginContainer/VBoxMain/HBoxContainer/ButtonContainer" groups=["MainMenu"] instance=ExtResource("1")]
+layout_mode = 2
 text = "New Game"
 
-[node name="Options" parent="BG/MarginContainer/VBoxMain/HBoxContainer/ButtonContainer" instance=ExtResource( 1 )]
-margin_top = 20.0
-margin_right = 51.0
-margin_bottom = 39.0
+[node name="Options" parent="BG/MarginContainer/VBoxMain/HBoxContainer/ButtonContainer" instance=ExtResource("1")]
+layout_mode = 2
 text = "Options"
 
-[node name="Exit" parent="BG/MarginContainer/VBoxMain/HBoxContainer/ButtonContainer" instance=ExtResource( 1 )]
-margin_top = 40.0
-margin_right = 51.0
-margin_bottom = 59.0
+[node name="Exit" parent="BG/MarginContainer/VBoxMain/HBoxContainer/ButtonContainer" instance=ExtResource("1")]
+layout_mode = 2
 text = "Exit"
 
-[node name="RightMargin" type="Control" parent="BG/MarginContainer/VBoxMain/HBoxContainer"]
-margin_left = 55.0
-margin_right = 288.0
-margin_bottom = 80.0
+[node name="CenterLogo" type="CenterContainer" parent="BG/MarginContainer/VBoxMain/HBoxContainer"]
+layout_mode = 2
 size_flags_horizontal = 3
-size_flags_vertical = 3
+
+[node name="Logo" type="TextureRect" parent="BG/MarginContainer/VBoxMain/HBoxContainer/CenterLogo"]
+layout_mode = 2
+texture = ExtResource("2")
 
 [connection signal="pressed" from="BG/MarginContainer/VBoxMain/HBoxContainer/ButtonContainer/NewGame" to="." method="_on_NewGame_pressed"]
 [connection signal="pressed" from="BG/MarginContainer/VBoxMain/HBoxContainer/ButtonContainer/Options" to="." method="_on_Options_pressed"]

--- a/GameTemplate/MainMenu/MainMenu.tscn
+++ b/GameTemplate/MainMenu/MainMenu.tscn
@@ -45,12 +45,13 @@ alignment = 1
 
 [node name="ButtonContainer" type="VBoxContainer" parent="BG/MarginContainer/VBoxMain/HBoxContainer"]
 layout_mode = 2
-size_flags_horizontal = 3
+size_flags_horizontal = 6
 size_flags_vertical = 6
 theme_override_constants/separation = 1
 
 [node name="NewGame" parent="BG/MarginContainer/VBoxMain/HBoxContainer/ButtonContainer" groups=["MainMenu"] instance=ExtResource("1")]
 layout_mode = 2
+size_flags_vertical = 3
 text = "New Game"
 
 [node name="Options" parent="BG/MarginContainer/VBoxMain/HBoxContainer/ButtonContainer" instance=ExtResource("1")]
@@ -59,6 +60,7 @@ text = "Options"
 
 [node name="Exit" parent="BG/MarginContainer/VBoxMain/HBoxContainer/ButtonContainer" instance=ExtResource("1")]
 layout_mode = 2
+size_flags_vertical = 3
 text = "Exit"
 
 [node name="CenterLogo" type="CenterContainer" parent="BG/MarginContainer/VBoxMain/HBoxContainer"]
@@ -72,3 +74,5 @@ texture = ExtResource("2")
 [connection signal="pressed" from="BG/MarginContainer/VBoxMain/HBoxContainer/ButtonContainer/NewGame" to="." method="_on_NewGame_pressed"]
 [connection signal="pressed" from="BG/MarginContainer/VBoxMain/HBoxContainer/ButtonContainer/Options" to="." method="_on_Options_pressed"]
 [connection signal="pressed" from="BG/MarginContainer/VBoxMain/HBoxContainer/ButtonContainer/Exit" to="." method="_on_Exit_pressed"]
+
+[editable path="BG/MarginContainer/VBoxMain/HBoxContainer/ButtonContainer/NewGame"]

--- a/GameTemplate/MainMenu/MainMenu.tscn
+++ b/GameTemplate/MainMenu/MainMenu.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=5 format=3 uid="uid://dcjkkkgaaqbqs"]
 
 [ext_resource type="PackedScene" uid="uid://dp81qs74tu3ba" path="res://addons/GameTemplate/GUI/Buttons/DefaultButton.tscn" id="1"]
-[ext_resource type="Texture2D" uid="uid://cb0tbpriomwqd" path="res://icon.png" id="2"]
+[ext_resource type="Texture2D" uid="uid://ctghwtp0t782j" path="res://icon.png" id="2"]
 [ext_resource type="Script" path="res://MainMenu/MainMenu.gd" id="3"]
 
 [sub_resource type="StyleBoxFlat" id="1"]

--- a/GameTemplate/addons/GameTemplate/Assets/Fonts/pixellocale_16.tres
+++ b/GameTemplate/addons/GameTemplate/Assets/Fonts/pixellocale_16.tres
@@ -1,6 +1,6 @@
-[gd_resource type="DynamicFont" load_steps=2 format=2]
+[gd_resource type="FontFile" load_steps=2 format=2]
 
-[ext_resource path="res://addons/GameTemplate/Assets/Fonts/pixellocale-v-1-4.ttf" type="DynamicFontData" id=1]
+[ext_resource path="res://addons/GameTemplate/Assets/Fonts/pixellocale-v-1-4.ttf" type="FontFile" id=1]
 
 [resource]
 outline_size = 1

--- a/GameTemplate/addons/GameTemplate/Assets/Fonts/pixellocale_32.tres
+++ b/GameTemplate/addons/GameTemplate/Assets/Fonts/pixellocale_32.tres
@@ -1,6 +1,6 @@
-[gd_resource type="DynamicFont" load_steps=2 format=2]
+[gd_resource type="FontFile" load_steps=2 format=2]
 
-[ext_resource path="res://addons/GameTemplate/Assets/Fonts/pixellocale-v-1-4.ttf" type="DynamicFontData" id=1]
+[ext_resource path="res://addons/GameTemplate/Assets/Fonts/pixellocale-v-1-4.ttf" type="FontFile" id=1]
 
 [resource]
 size = 32

--- a/GameTemplate/addons/GameTemplate/Assets/Fonts/pixellocale_64.tres
+++ b/GameTemplate/addons/GameTemplate/Assets/Fonts/pixellocale_64.tres
@@ -1,6 +1,6 @@
-[gd_resource type="DynamicFont" load_steps=2 format=2]
+[gd_resource type="FontFile" load_steps=2 format=2]
 
-[ext_resource path="res://addons/GameTemplate/Assets/Fonts/pixellocale-v-1-4.ttf" type="DynamicFontData" id=1]
+[ext_resource path="res://addons/GameTemplate/Assets/Fonts/pixellocale-v-1-4.ttf" type="FontFile" id=1]
 
 [resource]
 size = 64

--- a/GameTemplate/addons/GameTemplate/Assets/Fonts/pixellocale_8.tres
+++ b/GameTemplate/addons/GameTemplate/Assets/Fonts/pixellocale_8.tres
@@ -1,6 +1,6 @@
-[gd_resource type="DynamicFont" load_steps=2 format=2]
+[gd_resource type="FontFile" load_steps=2 format=2]
 
-[ext_resource path="res://addons/GameTemplate/Assets/Fonts/pixellocale-v-1-4.ttf" type="DynamicFontData" id=1]
+[ext_resource path="res://addons/GameTemplate/Assets/Fonts/pixellocale-v-1-4.ttf" type="FontFile" id=1]
 
 [resource]
 size = 8

--- a/GameTemplate/addons/GameTemplate/Assets/Fonts/pixellocale_8_noborder.tres
+++ b/GameTemplate/addons/GameTemplate/Assets/Fonts/pixellocale_8_noborder.tres
@@ -1,6 +1,6 @@
-[gd_resource type="DynamicFont" load_steps=2 format=2]
+[gd_resource type="FontFile" load_steps=2 format=2]
 
-[ext_resource path="res://addons/GameTemplate/Assets/Fonts/pixellocale-v-1-4.ttf" type="DynamicFontData" id=1]
+[ext_resource path="res://addons/GameTemplate/Assets/Fonts/pixellocale-v-1-4.ttf" type="FontFile" id=1]
 
 [resource]
 size = 8

--- a/GameTemplate/addons/GameTemplate/Assets/Images/Button1.png.import
+++ b/GameTemplate/addons/GameTemplate/Assets/Images/Button1.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/Button1.png-ec8c41f5bfdb95a102082dc70595e677.stex"
+type="CompressedTexture2D"
+uid="uid://c415qexcj6ro3"
+path="res://.godot/imported/Button1.png-ec8c41f5bfdb95a102082dc70595e677.ctex"
 metadata={
 "vram_texture": false
 }
@@ -10,25 +11,24 @@ metadata={
 [deps]
 
 source_file="res://addons/GameTemplate/Assets/Images/Button1.png"
-dest_files=[ "res://.import/Button1.png-ec8c41f5bfdb95a102082dc70595e677.stex" ]
+dest_files=["res://.godot/imported/Button1.png-ec8c41f5bfdb95a102082dc70595e677.ctex"]
 
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
-compress/hdr_mode=0
-compress/bptc_ldr=0
+compress/hdr_compression=1
 compress/normal_map=0
-flags/repeat=0
-flags/filter=false
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
-process/HDR_as_SRGB=false
-process/invert_color=false
-stream=false
-size_limit=0
-detect_3d=false
-svg/scale=1.0
+process/normal_map_invert_y=false
+process/hdr_as_srgb=false
+process/hdr_clamp_exposure=false
+process/size_limit=0
+detect_3d/compress_to=1

--- a/GameTemplate/addons/GameTemplate/Assets/Images/Button2.png.import
+++ b/GameTemplate/addons/GameTemplate/Assets/Images/Button2.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/Button2.png-e6ac7a089cadb8fc69e46a71316872a0.stex"
+type="CompressedTexture2D"
+uid="uid://dwprkjlb40yti"
+path="res://.godot/imported/Button2.png-e6ac7a089cadb8fc69e46a71316872a0.ctex"
 metadata={
 "vram_texture": false
 }
@@ -10,25 +11,24 @@ metadata={
 [deps]
 
 source_file="res://addons/GameTemplate/Assets/Images/Button2.png"
-dest_files=[ "res://.import/Button2.png-e6ac7a089cadb8fc69e46a71316872a0.stex" ]
+dest_files=["res://.godot/imported/Button2.png-e6ac7a089cadb8fc69e46a71316872a0.ctex"]
 
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
-compress/hdr_mode=0
-compress/bptc_ldr=0
+compress/hdr_compression=1
 compress/normal_map=0
-flags/repeat=0
-flags/filter=false
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
-process/HDR_as_SRGB=false
-process/invert_color=false
-stream=false
-size_limit=0
-detect_3d=false
-svg/scale=1.0
+process/normal_map_invert_y=false
+process/hdr_as_srgb=false
+process/hdr_clamp_exposure=false
+process/size_limit=0
+detect_3d/compress_to=1

--- a/GameTemplate/addons/GameTemplate/Assets/Images/Button3.png.import
+++ b/GameTemplate/addons/GameTemplate/Assets/Images/Button3.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/Button3.png-5799839507719d63cf32ef06edfd5eae.stex"
+type="CompressedTexture2D"
+uid="uid://u210kf7lg47v"
+path="res://.godot/imported/Button3.png-5799839507719d63cf32ef06edfd5eae.ctex"
 metadata={
 "vram_texture": false
 }
@@ -10,25 +11,24 @@ metadata={
 [deps]
 
 source_file="res://addons/GameTemplate/Assets/Images/Button3.png"
-dest_files=[ "res://.import/Button3.png-5799839507719d63cf32ef06edfd5eae.stex" ]
+dest_files=["res://.godot/imported/Button3.png-5799839507719d63cf32ef06edfd5eae.ctex"]
 
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
-compress/hdr_mode=0
-compress/bptc_ldr=0
+compress/hdr_compression=1
 compress/normal_map=0
-flags/repeat=0
-flags/filter=false
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
-process/HDR_as_SRGB=false
-process/invert_color=false
-stream=false
-size_limit=0
-detect_3d=false
-svg/scale=1.0
+process/normal_map_invert_y=false
+process/hdr_as_srgb=false
+process/hdr_clamp_exposure=false
+process/size_limit=0
+detect_3d/compress_to=1

--- a/GameTemplate/addons/GameTemplate/Assets/Images/Slider1.png.import
+++ b/GameTemplate/addons/GameTemplate/Assets/Images/Slider1.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/Slider1.png-a6ac496fe0ccb867eadbdb42b7ebb6bc.stex"
+type="CompressedTexture2D"
+uid="uid://cmov50y4ytc16"
+path="res://.godot/imported/Slider1.png-a6ac496fe0ccb867eadbdb42b7ebb6bc.ctex"
 metadata={
 "vram_texture": false
 }
@@ -10,25 +11,24 @@ metadata={
 [deps]
 
 source_file="res://addons/GameTemplate/Assets/Images/Slider1.png"
-dest_files=[ "res://.import/Slider1.png-a6ac496fe0ccb867eadbdb42b7ebb6bc.stex" ]
+dest_files=["res://.godot/imported/Slider1.png-a6ac496fe0ccb867eadbdb42b7ebb6bc.ctex"]
 
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
-compress/hdr_mode=0
-compress/bptc_ldr=0
+compress/hdr_compression=1
 compress/normal_map=0
-flags/repeat=0
-flags/filter=false
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
-process/HDR_as_SRGB=false
-process/invert_color=false
-stream=false
-size_limit=0
-detect_3d=false
-svg/scale=1.0
+process/normal_map_invert_y=false
+process/hdr_as_srgb=false
+process/hdr_clamp_exposure=false
+process/size_limit=0
+detect_3d/compress_to=1

--- a/GameTemplate/addons/GameTemplate/Assets/Images/Slider2.png.import
+++ b/GameTemplate/addons/GameTemplate/Assets/Images/Slider2.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/Slider2.png-25c854d284088cfbe67c0a246dbbc61d.stex"
+type="CompressedTexture2D"
+uid="uid://cvq85e6qqmqsr"
+path="res://.godot/imported/Slider2.png-25c854d284088cfbe67c0a246dbbc61d.ctex"
 metadata={
 "vram_texture": false
 }
@@ -10,25 +11,24 @@ metadata={
 [deps]
 
 source_file="res://addons/GameTemplate/Assets/Images/Slider2.png"
-dest_files=[ "res://.import/Slider2.png-25c854d284088cfbe67c0a246dbbc61d.stex" ]
+dest_files=["res://.godot/imported/Slider2.png-25c854d284088cfbe67c0a246dbbc61d.ctex"]
 
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
-compress/hdr_mode=0
-compress/bptc_ldr=0
+compress/hdr_compression=1
 compress/normal_map=0
-flags/repeat=0
-flags/filter=false
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
-process/HDR_as_SRGB=false
-process/invert_color=false
-stream=false
-size_limit=0
-detect_3d=false
-svg/scale=1.0
+process/normal_map_invert_y=false
+process/hdr_as_srgb=false
+process/hdr_clamp_exposure=false
+process/size_limit=0
+detect_3d/compress_to=1

--- a/GameTemplate/addons/GameTemplate/Assets/Images/SliderGrabber1.png.import
+++ b/GameTemplate/addons/GameTemplate/Assets/Images/SliderGrabber1.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/SliderGrabber1.png-a82913642f4db1fe87d13529bfb441e2.stex"
+type="CompressedTexture2D"
+uid="uid://c3texvstwa4yx"
+path="res://.godot/imported/SliderGrabber1.png-a82913642f4db1fe87d13529bfb441e2.ctex"
 metadata={
 "vram_texture": false
 }
@@ -10,25 +11,24 @@ metadata={
 [deps]
 
 source_file="res://addons/GameTemplate/Assets/Images/SliderGrabber1.png"
-dest_files=[ "res://.import/SliderGrabber1.png-a82913642f4db1fe87d13529bfb441e2.stex" ]
+dest_files=["res://.godot/imported/SliderGrabber1.png-a82913642f4db1fe87d13529bfb441e2.ctex"]
 
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
-compress/hdr_mode=0
-compress/bptc_ldr=0
+compress/hdr_compression=1
 compress/normal_map=0
-flags/repeat=0
-flags/filter=false
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
-process/HDR_as_SRGB=false
-process/invert_color=false
-stream=false
-size_limit=0
-detect_3d=false
-svg/scale=1.0
+process/normal_map_invert_y=false
+process/hdr_as_srgb=false
+process/hdr_clamp_exposure=false
+process/size_limit=0
+detect_3d/compress_to=1

--- a/GameTemplate/addons/GameTemplate/Assets/Images/SliderGrabber2.png.import
+++ b/GameTemplate/addons/GameTemplate/Assets/Images/SliderGrabber2.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/SliderGrabber2.png-236b658512bed687a7b9777f336786b3.stex"
+type="CompressedTexture2D"
+uid="uid://unw2786rna32"
+path="res://.godot/imported/SliderGrabber2.png-236b658512bed687a7b9777f336786b3.ctex"
 metadata={
 "vram_texture": false
 }
@@ -10,25 +11,24 @@ metadata={
 [deps]
 
 source_file="res://addons/GameTemplate/Assets/Images/SliderGrabber2.png"
-dest_files=[ "res://.import/SliderGrabber2.png-236b658512bed687a7b9777f336786b3.stex" ]
+dest_files=["res://.godot/imported/SliderGrabber2.png-236b658512bed687a7b9777f336786b3.ctex"]
 
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
-compress/hdr_mode=0
-compress/bptc_ldr=0
+compress/hdr_compression=1
 compress/normal_map=0
-flags/repeat=0
-flags/filter=false
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
-process/HDR_as_SRGB=false
-process/invert_color=false
-stream=false
-size_limit=0
-detect_3d=false
-svg/scale=1.0
+process/normal_map_invert_y=false
+process/hdr_as_srgb=false
+process/hdr_clamp_exposure=false
+process/size_limit=0
+detect_3d/compress_to=1

--- a/GameTemplate/addons/GameTemplate/Assets/Images/Toggle1.png.import
+++ b/GameTemplate/addons/GameTemplate/Assets/Images/Toggle1.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/Toggle1.png-205a294879ab760c0245fec80ab0dce9.stex"
+type="CompressedTexture2D"
+uid="uid://b3jtgefxnf8bp"
+path="res://.godot/imported/Toggle1.png-205a294879ab760c0245fec80ab0dce9.ctex"
 metadata={
 "vram_texture": false
 }
@@ -10,25 +11,24 @@ metadata={
 [deps]
 
 source_file="res://addons/GameTemplate/Assets/Images/Toggle1.png"
-dest_files=[ "res://.import/Toggle1.png-205a294879ab760c0245fec80ab0dce9.stex" ]
+dest_files=["res://.godot/imported/Toggle1.png-205a294879ab760c0245fec80ab0dce9.ctex"]
 
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
-compress/hdr_mode=0
-compress/bptc_ldr=0
+compress/hdr_compression=1
 compress/normal_map=0
-flags/repeat=0
-flags/filter=false
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
-process/HDR_as_SRGB=false
-process/invert_color=false
-stream=false
-size_limit=0
-detect_3d=false
-svg/scale=1.0
+process/normal_map_invert_y=false
+process/hdr_as_srgb=false
+process/hdr_clamp_exposure=false
+process/size_limit=0
+detect_3d/compress_to=1

--- a/GameTemplate/addons/GameTemplate/Assets/Images/Toggle2.png.import
+++ b/GameTemplate/addons/GameTemplate/Assets/Images/Toggle2.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/Toggle2.png-77fd11241db781e0c4a9253ba49571d8.stex"
+type="CompressedTexture2D"
+uid="uid://bqyndunb1t7o7"
+path="res://.godot/imported/Toggle2.png-77fd11241db781e0c4a9253ba49571d8.ctex"
 metadata={
 "vram_texture": false
 }
@@ -10,25 +11,24 @@ metadata={
 [deps]
 
 source_file="res://addons/GameTemplate/Assets/Images/Toggle2.png"
-dest_files=[ "res://.import/Toggle2.png-77fd11241db781e0c4a9253ba49571d8.stex" ]
+dest_files=["res://.godot/imported/Toggle2.png-77fd11241db781e0c4a9253ba49571d8.ctex"]
 
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
-compress/hdr_mode=0
-compress/bptc_ldr=0
+compress/hdr_compression=1
 compress/normal_map=0
-flags/repeat=0
-flags/filter=false
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
-process/HDR_as_SRGB=false
-process/invert_color=false
-stream=false
-size_limit=0
-detect_3d=false
-svg/scale=1.0
+process/normal_map_invert_y=false
+process/hdr_as_srgb=false
+process/hdr_clamp_exposure=false
+process/size_limit=0
+detect_3d/compress_to=1

--- a/GameTemplate/addons/GameTemplate/Assets/Sounds/TestBeep.wav.import
+++ b/GameTemplate/addons/GameTemplate/Assets/Sounds/TestBeep.wav.import
@@ -1,13 +1,14 @@
 [remap]
 
 importer="wav"
-type="AudioStreamSample"
-path="res://.import/TestBeep.wav-3ed18d3cc5db3a0921faf7e9a8c65e92.sample"
+type="AudioStreamWAV"
+uid="uid://cso0x0vfiblhw"
+path="res://.godot/imported/TestBeep.wav-3ed18d3cc5db3a0921faf7e9a8c65e92.sample"
 
 [deps]
 
 source_file="res://addons/GameTemplate/Assets/Sounds/TestBeep.wav"
-dest_files=[ "res://.import/TestBeep.wav-3ed18d3cc5db3a0921faf7e9a8c65e92.sample" ]
+dest_files=["res://.godot/imported/TestBeep.wav-3ed18d3cc5db3a0921faf7e9a8c65e92.sample"]
 
 [params]
 
@@ -17,5 +18,7 @@ force/max_rate=false
 force/max_rate_hz=44100
 edit/trim=false
 edit/normalize=false
-edit/loop=false
+edit/loop_mode=0
+edit/loop_begin=0
+edit/loop_end=-1
 compress/mode=0

--- a/GameTemplate/addons/GameTemplate/Autoload/Game.gd
+++ b/GameTemplate/addons/GameTemplate/Autoload/Game.gd
@@ -7,45 +7,44 @@ signal Restart		#Reloads current scene
 signal ChangeScene	#Pass location of next scene file
 signal Exit			#Triggers closing the game
 
-onready var CurrentScene = null
+@onready var CurrentScene = null
 var NextScene
 
 var loader: = ResourceAsyncLoader.new()
 
 func _ready()->void:
-	connect("Exit",			self, "on_Exit")
-	connect("ChangeScene",	self, "on_ChangeScene")
-	connect("Restart", 		self, "restart_scene")
+	connect("Exit", on_Exit)
+	connect("ChangeScene", on_ChangeScene)
+	connect("Restart", restart_scene)
 
 func on_ChangeScene(scene)->void:
-	if ScreenFade.state != ScreenFade.IDLE:
+	if ScreenFade.state != ScreenFade.fade_type.IDLE:
 		return
-	ScreenFade.state = ScreenFade.OUT
+	ScreenFade.state = ScreenFade.fade_type.OUT
 	if loader.can_async:
-		NextScene = yield(loader.load_start( [scene] ), "completed")[0]				#Using ResourceAsyncLoader to load in next scene - it takes in array list and gives back array
+		var a = await loader.load_start( [scene] )
+		NextScene = a[0]				#Using ResourceAsyncLoader to load in next scene - it takes in array list and gives back array
 	else:
-		NextScene = loader.load_start( [scene] )[0]
+		var a = await loader.load_start( [scene] )
+		NextScene = a[0]
 	if NextScene == null:
 		print(' Game.gd 36 - Loaded.resource is null')
 		return
-	if ScreenFade.state != ScreenFade.BLACK:
-		yield(ScreenFade, "fade_complete")
+	if ScreenFade.state != ScreenFade.fade_type.BLACK:
+		await ScreenFade.fade_complete
 	switch_scene()
-	ScreenFade.state = ScreenFade.IN
+	ScreenFade.state = ScreenFade.fade_type.IN
 
 func switch_scene()->void: 														#handles actual scene change
 	CurrentScene = NextScene
 	NextScene = null
-	get_tree().change_scene_to(CurrentScene)
+	get_tree().change_scene_to_packed(CurrentScene)
 
 func restart_scene()->void:
-	if ScreenFade.state != ScreenFade.IDLE:
-		return
 	get_tree().reload_current_scene()
 
 
 func on_Exit()->void:
-	if ScreenFade.state != ScreenFade.IDLE:
+	if ScreenFade.state != ScreenFade.fade_type.IDLE:
 		return
 	get_tree().quit()
-

--- a/GameTemplate/addons/GameTemplate/Autoload/HtmlFocus.tscn
+++ b/GameTemplate/addons/GameTemplate/Autoload/HtmlFocus.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=8 format=2]
 
-[ext_resource path="res://addons/GameTemplate/Assets/Fonts/pixellocale_16.tres" type="DynamicFont" id=1]
+[ext_resource path="res://addons/GameTemplate/Assets/Fonts/pixellocale_16.tres" type="FontFile" id=1]
 
 
 [sub_resource type="GDScript" id=1]
@@ -10,7 +10,7 @@ func _ready()->void:
 	if OS.get_name() != \"HTML5\":
 		queue_free()
 		return
-	$CanvasLayer/Button.connect(\"pressed\", self, \"_on_Button_pressed\")
+	$CanvasLayer/Button.connect(\"pressed\", Callable(self, \"_on_Button_pressed\"))
 	$CanvasLayer/Panel.show()
 	$CanvasLayer/Button.show()
 
@@ -42,10 +42,10 @@ anchor_bottom = 1.0
 [node name="Button" type="Button" parent="CanvasLayer"]
 anchor_right = 1.0
 anchor_bottom = 1.0
-custom_styles/hover = SubResource( 2 )
-custom_styles/pressed = SubResource( 3 )
-custom_styles/focus = SubResource( 4 )
-custom_styles/disabled = SubResource( 5 )
-custom_styles/normal = SubResource( 6 )
-custom_fonts/font = ExtResource( 1 )
+theme_override_styles/hover = SubResource( 2 )
+theme_override_styles/pressed = SubResource( 3 )
+theme_override_styles/focus = SubResource( 4 )
+theme_override_styles/disabled = SubResource( 5 )
+theme_override_styles/normal = SubResource( 6 )
+theme_override_fonts/font = ExtResource( 1 )
 text = "Click me"

--- a/GameTemplate/addons/GameTemplate/Autoload/HtmlFocus.tscn
+++ b/GameTemplate/addons/GameTemplate/Autoload/HtmlFocus.tscn
@@ -1,51 +1,54 @@
-[gd_scene load_steps=8 format=2]
+[gd_scene load_steps=8 format=3 uid="uid://p2vqgqnlaq1l"]
 
-[ext_resource path="res://addons/GameTemplate/Assets/Fonts/pixellocale_16.tres" type="FontFile" id=1]
+[ext_resource type="FontFile" path="res://addons/GameTemplate/Assets/Fonts/pixellocale_16.tres" id="1"]
 
-
-[sub_resource type="GDScript" id=1]
+[sub_resource type="GDScript" id="1"]
 script/source = "extends Node
 
 func _ready()->void:
-	if OS.get_name() != \"HTML5\":
+	if !OS.has_feature('web'):
 		queue_free()
 		return
-	$CanvasLayer/Button.connect(\"pressed\", Callable(self, \"_on_Button_pressed\"))
+	$CanvasLayer/Button.connect(\"pressed\", _on_Button_pressed)
 	$CanvasLayer/Panel.show()
 	$CanvasLayer/Button.show()
 
 func _on_Button_pressed()->void:
+	get_tree().get_nodes_in_group(\"MainMenu\")[0].grab_focus()
 	queue_free()
 "
 
-[sub_resource type="StyleBoxEmpty" id=2]
+[sub_resource type="StyleBoxEmpty" id="4"]
 
-[sub_resource type="StyleBoxEmpty" id=3]
+[sub_resource type="StyleBoxEmpty" id="5"]
 
-[sub_resource type="StyleBoxEmpty" id=4]
+[sub_resource type="StyleBoxEmpty" id="2"]
 
-[sub_resource type="StyleBoxEmpty" id=5]
+[sub_resource type="StyleBoxEmpty" id="3"]
 
-[sub_resource type="StyleBoxEmpty" id=6]
+[sub_resource type="StyleBoxEmpty" id="6"]
 
 [node name="HtmlFocus" type="Node"]
-script = SubResource( 1 )
+script = SubResource("1")
 
 [node name="CanvasLayer" type="CanvasLayer" parent="."]
 layer = 128
 
 [node name="Panel" type="Panel" parent="CanvasLayer"]
-modulate = Color( 1, 1, 1, 0.611765 )
+modulate = Color(1, 1, 1, 0.611765)
+anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 
 [node name="Button" type="Button" parent="CanvasLayer"]
+anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
-theme_override_styles/hover = SubResource( 2 )
-theme_override_styles/pressed = SubResource( 3 )
-theme_override_styles/focus = SubResource( 4 )
-theme_override_styles/disabled = SubResource( 5 )
-theme_override_styles/normal = SubResource( 6 )
-theme_override_fonts/font = ExtResource( 1 )
+theme_override_fonts/font = ExtResource("1")
+theme_override_font_sizes/font_size = 18
+theme_override_styles/focus = SubResource("4")
+theme_override_styles/disabled = SubResource("5")
+theme_override_styles/hover = SubResource("2")
+theme_override_styles/pressed = SubResource("3")
+theme_override_styles/normal = SubResource("6")
 text = "Click me"

--- a/GameTemplate/addons/GameTemplate/Autoload/Hud.tscn
+++ b/GameTemplate/addons/GameTemplate/Autoload/Hud.tscn
@@ -1,15 +1,15 @@
-[gd_scene load_steps=3 format=2]
+[gd_scene load_steps=4 format=3 uid="uid://bx30gp07d80ma"]
 
-[ext_resource path="res://addons/GameTemplate/Assets/Fonts/pixellocale_16.tres" type="DynamicFont" id=1]
+[ext_resource type="FontFile" uid="uid://cj1os0is1qn2h" path="res://addons/GameTemplate/Assets/Fonts/pixellocale-v-1-4.ttf" id="1_v15ma"]
 
-[sub_resource type="GDScript" id=1]
+[sub_resource type="GDScript" id="1"]
 script/source = "extends Node
 
-onready var hp: = $CanvasLayer/GUI/MarginContainer/VBoxContainer/Top/HP
-onready var score: = $CanvasLayer/GUI/MarginContainer/VBoxContainer/Top/Score
-onready var gui: = $CanvasLayer/GUI
+@onready var hp: = $CanvasLayer/GUI/MarginContainer/VBoxContainer/Top/HP
+@onready var score: = $CanvasLayer/GUI/MarginContainer/VBoxContainer/Top/Score
+@onready var gui: = $CanvasLayer/GUI
 
-var visible: = false setget set_visible
+var visible: = false: set = set_visible
 
 func _ready()->void:
 	gui.visible = visible
@@ -19,55 +19,110 @@ func set_visible(value: bool)->void:
 	gui.visible = value
 "
 
+[sub_resource type="FontFile" id="FontFile_4wxgj"]
+fallbacks = Array[Font]([ExtResource("1_v15ma")])
+cache/0/16/0/ascent = 0.0
+cache/0/16/0/descent = 0.0
+cache/0/16/0/underline_position = 0.0
+cache/0/16/0/underline_thickness = 0.0
+cache/0/16/0/scale = 1.0
+cache/0/50/0/ascent = 0.0
+cache/0/50/0/descent = 0.0
+cache/0/50/0/underline_position = 0.0
+cache/0/50/0/underline_thickness = 0.0
+cache/0/50/0/scale = 1.0
+cache/0/2/0/ascent = 0.0
+cache/0/2/0/descent = 0.0
+cache/0/2/0/underline_position = 0.0
+cache/0/2/0/underline_thickness = 0.0
+cache/0/2/0/scale = 1.0
+cache/0/3/0/ascent = 0.0
+cache/0/3/0/descent = 0.0
+cache/0/3/0/underline_position = 0.0
+cache/0/3/0/underline_thickness = 0.0
+cache/0/3/0/scale = 1.0
+cache/0/4/0/ascent = 0.0
+cache/0/4/0/descent = 0.0
+cache/0/4/0/underline_position = 0.0
+cache/0/4/0/underline_thickness = 0.0
+cache/0/4/0/scale = 1.0
+cache/0/5/0/ascent = 0.0
+cache/0/5/0/descent = 0.0
+cache/0/5/0/underline_position = 0.0
+cache/0/5/0/underline_thickness = 0.0
+cache/0/5/0/scale = 1.0
+cache/0/6/0/ascent = 0.0
+cache/0/6/0/descent = 0.0
+cache/0/6/0/underline_position = 0.0
+cache/0/6/0/underline_thickness = 0.0
+cache/0/6/0/scale = 1.0
+cache/0/7/0/ascent = 0.0
+cache/0/7/0/descent = 0.0
+cache/0/7/0/underline_position = 0.0
+cache/0/7/0/underline_thickness = 0.0
+cache/0/7/0/scale = 1.0
+cache/0/8/0/ascent = 0.0
+cache/0/8/0/descent = 0.0
+cache/0/8/0/underline_position = 0.0
+cache/0/8/0/underline_thickness = 0.0
+cache/0/8/0/scale = 1.0
+cache/0/9/0/ascent = 0.0
+cache/0/9/0/descent = 0.0
+cache/0/9/0/underline_position = 0.0
+cache/0/9/0/underline_thickness = 0.0
+cache/0/9/0/scale = 1.0
+cache/0/10/0/ascent = 0.0
+cache/0/10/0/descent = 0.0
+cache/0/10/0/underline_position = 0.0
+cache/0/10/0/underline_thickness = 0.0
+cache/0/10/0/scale = 1.0
+cache/0/15/0/ascent = 0.0
+cache/0/15/0/descent = 0.0
+cache/0/15/0/underline_position = 0.0
+cache/0/15/0/underline_thickness = 0.0
+cache/0/15/0/scale = 1.0
+
 [node name="Hud" type="Node"]
-script = SubResource( 1 )
+script = SubResource("1")
 
 [node name="CanvasLayer" type="CanvasLayer" parent="."]
 layer = 10
 
 [node name="GUI" type="Control" parent="CanvasLayer"]
+layout_mode = 3
+anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
 mouse_filter = 2
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="MarginContainer" type="MarginContainer" parent="CanvasLayer/GUI"]
+layout_mode = 0
 anchor_right = 1.0
 anchor_bottom = 1.0
 mouse_filter = 2
-custom_constants/margin_right = 4
-custom_constants/margin_top = 4
-custom_constants/margin_left = 4
-custom_constants/margin_bottom = 4
-__meta__ = {
-"_edit_use_anchors_": false
-}
+theme_override_constants/margin_left = 4
+theme_override_constants/margin_top = 4
+theme_override_constants/margin_right = 4
+theme_override_constants/margin_bottom = 4
 
 [node name="VBoxContainer" type="VBoxContainer" parent="CanvasLayer/GUI/MarginContainer"]
-margin_left = 4.0
-margin_top = 4.0
-margin_right = 316.0
-margin_bottom = 176.0
+layout_mode = 2
 mouse_filter = 2
 
 [node name="Top" type="HBoxContainer" parent="CanvasLayer/GUI/MarginContainer/VBoxContainer"]
-margin_right = 312.0
-margin_bottom = 34.0
+layout_mode = 2
 mouse_filter = 2
 
 [node name="HP" type="Label" parent="CanvasLayer/GUI/MarginContainer/VBoxContainer/Top"]
-margin_right = 193.0
-margin_bottom = 34.0
+layout_mode = 2
 size_flags_horizontal = 3
-custom_fonts/font = ExtResource( 1 )
+theme_override_fonts/font = SubResource("FontFile_4wxgj")
 text = "HP: 3"
 
 [node name="Score" type="Label" parent="CanvasLayer/GUI/MarginContainer/VBoxContainer/Top"]
-margin_left = 197.0
-margin_right = 312.0
-margin_bottom = 34.0
-custom_fonts/font = ExtResource( 1 )
+layout_mode = 2
+theme_override_fonts/font = SubResource("FontFile_4wxgj")
 text = "Score: 0000"
-align = 2
+horizontal_alignment = 2

--- a/GameTemplate/addons/GameTemplate/Autoload/Hud.tscn
+++ b/GameTemplate/addons/GameTemplate/Autoload/Hud.tscn
@@ -1,8 +1,9 @@
 [gd_scene load_steps=4 format=3 uid="uid://bx30gp07d80ma"]
 
-[ext_resource type="FontFile" uid="uid://cj1os0is1qn2h" path="res://addons/GameTemplate/Assets/Fonts/pixellocale-v-1-4.ttf" id="1_v15ma"]
+[ext_resource type="FontFile" uid="uid://2b17u8f57klu" path="res://addons/GameTemplate/Assets/Fonts/pixellocale-v-1-4.ttf" id="1_v15ma"]
 
-[sub_resource type="GDScript" id="1"]
+[sub_resource type="GDScript" id="GDScript_df33i"]
+resource_name = "Hud"
 script/source = "extends Node
 
 @onready var hp: = $CanvasLayer/GUI/MarginContainer/VBoxContainer/Top/HP
@@ -83,7 +84,7 @@ cache/0/15/0/underline_thickness = 0.0
 cache/0/15/0/scale = 1.0
 
 [node name="Hud" type="Node"]
-script = SubResource("1")
+script = SubResource("GDScript_df33i")
 
 [node name="CanvasLayer" type="CanvasLayer" parent="."]
 layer = 10

--- a/GameTemplate/addons/GameTemplate/Autoload/MenuEvent.gd
+++ b/GameTemplate/addons/GameTemplate/Autoload/MenuEvent.gd
@@ -1,52 +1,57 @@
 extends Node
 
-signal Options
-signal Controls
-signal Languages
-signal Paused
-signal Refocus
+signal OptionsSignal
+signal ControlsSignal
+signal LanguagesSignal
+signal PausedSignal
+signal RefocusSignal
 
 #For section tracking
-var Options:bool = false setget set_options
-var Controls:bool = false setget set_controls
-var Languages:bool = false setget set_languages
-var Paused: bool = false setget set_paused
+var Options_val = false: set = set_options
+var Controls_val = false: set = set_controls
+var Languages_val = false: set = set_languages
+var Paused_val = false: set = set_paused
 
 func set_options(value:bool)->void:
-	Options = value
-	emit_signal("Options", Options)
+	Options_val = value
+	emit_signal("OptionsSignal", Options_val)
 
 func set_controls(value:bool)->void:
-	Controls = value
-	emit_signal("Controls", Controls)
+	Controls_val = value
+	emit_signal("ControlsSignal", Controls_val)
 
 func set_languages(value:bool)->void:
-	Languages = value
-	emit_signal("Languages", Languages)
+	Languages_val = value
+	emit_signal("LanguagesSignal", Languages_val)
 
 func set_paused(value:bool)->void:
-	Paused = value
-	get_tree().paused = value
-	emit_signal("Paused", Paused)
+	Paused_val = value
+	get_tree().paused = Paused_val
+	emit_signal("PausedSignal", Paused_val)
 
 func _ready()->void:
-	pause_mode = Node.PAUSE_MODE_PROCESS										#when pause menu allows reading inputs
+	process_mode = Node.PROCESS_MODE_ALWAYS										#when pause menu allows reading inputs
 
-func _input(event)->void:												#used to get back in menus
+func _input(event: InputEvent) -> void:
 	if event.is_action_pressed("ui_cancel"):
-		if Languages:
+		if Languages_val:
 			set_languages(false)
-		elif Controls:
+		elif Controls_val:
 			# ignore back button when entering key
 			if !get_tree().get_nodes_in_group("KeyBinding")[0].visible:
 				set_controls(false)
 			else:
 				return
-		elif Options:
+		elif Options_val:
 			set_options(false)
 			if PauseMenu.can_show:
-				PauseMenu.show(true)
-		elif Paused:
-			PauseMenu.show(false)
+				PauseMenu.show_menu(true)
+		elif Paused_val:
+			PauseMenu.show_menu(false)
 		elif PauseMenu.can_show:
-			PauseMenu.show(true)
+			PauseMenu.show_menu(true)
+	elif event.is_action_pressed("ui_select"):
+		if Paused_val:
+			PauseMenu.show_menu(false)
+		elif PauseMenu.can_show:
+			PauseMenu.show_menu(true)

--- a/GameTemplate/addons/GameTemplate/Autoload/MenuEvent.gd
+++ b/GameTemplate/addons/GameTemplate/Autoload/MenuEvent.gd
@@ -46,6 +46,10 @@ func _input(event: InputEvent) -> void:
 			set_options(false)
 			if PauseMenu.can_show:
 				PauseMenu.show_menu(true)
+		elif Paused_val and event is InputEventKey:
+			PauseMenu.show_menu(false)
+		elif PauseMenu.can_show:
+			PauseMenu.show_menu(true)
 	elif event.is_action_pressed("ui_select"):
 		if Paused_val:
 			PauseMenu.show_menu(false)

--- a/GameTemplate/addons/GameTemplate/Autoload/MenuEvent.gd
+++ b/GameTemplate/addons/GameTemplate/Autoload/MenuEvent.gd
@@ -46,10 +46,6 @@ func _input(event: InputEvent) -> void:
 			set_options(false)
 			if PauseMenu.can_show:
 				PauseMenu.show_menu(true)
-		elif Paused_val:
-			PauseMenu.show_menu(false)
-		elif PauseMenu.can_show:
-			PauseMenu.show_menu(true)
 	elif event.is_action_pressed("ui_select"):
 		if Paused_val:
 			PauseMenu.show_menu(false)

--- a/GameTemplate/addons/GameTemplate/Autoload/Music.tscn
+++ b/GameTemplate/addons/GameTemplate/Autoload/Music.tscn
@@ -3,7 +3,7 @@
 [sub_resource type="GDScript" id=1]
 script/source = "extends Node
 
-onready var audio:AudioStreamPlayer = $AudioStreamPlayer
+@onready var audio:AudioStreamPlayer = $AudioStreamPlayer
 
 func play(music:Resource)->void:
 	audio.stream = music

--- a/GameTemplate/addons/GameTemplate/Autoload/Opt3755.tmp
+++ b/GameTemplate/addons/GameTemplate/Autoload/Opt3755.tmp
@@ -1,8 +1,8 @@
-[gd_scene load_steps=6 format=3 uid="uid://mm7txw32xv4i"]
+[gd_scene load_steps=6 format=3 uid="uid://b0cxglpagu4xe"]
 
-[ext_resource type="PackedScene" uid="uid://dv20udv56ebyy" path="res://addons/GameTemplate/GUI/OptionsSections/Languages.tscn" id="1"]
+[ext_resource type="PackedScene" path="res://addons/GameTemplate/GUI/OptionsSections/Languages.tscn" id="1"]
 [ext_resource type="PackedScene" path="res://addons/GameTemplate/GUI/OptionsSections/Controls.tscn" id="2"]
-[ext_resource type="PackedScene" uid="uid://ssfa3xrbdxx5" path="res://addons/GameTemplate/GUI/OptionsSections/General.tscn" id="3"]
+[ext_resource type="PackedScene" path="res://addons/GameTemplate/GUI/OptionsSections/General.tscn" id="3"]
 
 [sub_resource type="GDScript" id="1"]
 script/source = "
@@ -10,13 +10,13 @@ extends Node
 
 func _ready()->void:
 	#show main section and hide controls
-	MenuEvent.connect(\"OptionsSignal\", on_show_options)
-	MenuEvent.Controls_val = false
+	MenuEvent.connect(\"Options\", Callable(self, \"on_show_options\"))
+	MenuEvent.ControlsSignal = false
 	$OptionsMenu/BG.visible = false
 
 func on_show_options(value:bool)->void:
 	$OptionsMenu/BG.visible = value
-	MenuEvent.Controls_val = false
+	MenuEvent.ControlsSignal = false
 "
 
 [sub_resource type="StyleBoxFlat" id="2"]

--- a/GameTemplate/addons/GameTemplate/Autoload/Opt8B0F.tmp
+++ b/GameTemplate/addons/GameTemplate/Autoload/Opt8B0F.tmp
@@ -1,6 +1,6 @@
 [gd_scene load_steps=6 format=3 uid="uid://mm7txw32xv4i"]
 
-[ext_resource type="PackedScene" uid="uid://dv20udv56ebyy" path="res://addons/GameTemplate/GUI/OptionsSections/Languages.tscn" id="1"]
+[ext_resource type="PackedScene" path="res://addons/GameTemplate/GUI/OptionsSections/Languages.tscn" id="1"]
 [ext_resource type="PackedScene" path="res://addons/GameTemplate/GUI/OptionsSections/Controls.tscn" id="2"]
 [ext_resource type="PackedScene" uid="uid://ssfa3xrbdxx5" path="res://addons/GameTemplate/GUI/OptionsSections/General.tscn" id="3"]
 
@@ -10,13 +10,13 @@ extends Node
 
 func _ready()->void:
 	#show main section and hide controls
-	MenuEvent.connect(\"OptionsSignal\", on_show_options)
-	MenuEvent.Controls_val = false
+	MenuEvent.connect(\"Options\", Callable(self, \"on_show_options\"))
+	MenuEvent.Controls = false
 	$OptionsMenu/BG.visible = false
 
 func on_show_options(value:bool)->void:
 	$OptionsMenu/BG.visible = value
-	MenuEvent.Controls_val = false
+	MenuEvent.Controls = false
 "
 
 [sub_resource type="StyleBoxFlat" id="2"]

--- a/GameTemplate/addons/GameTemplate/Autoload/OptD8B7.tmp
+++ b/GameTemplate/addons/GameTemplate/Autoload/OptD8B7.tmp
@@ -1,6 +1,6 @@
 [gd_scene load_steps=6 format=3 uid="uid://mm7txw32xv4i"]
 
-[ext_resource type="PackedScene" uid="uid://dv20udv56ebyy" path="res://addons/GameTemplate/GUI/OptionsSections/Languages.tscn" id="1"]
+[ext_resource type="PackedScene" path="res://addons/GameTemplate/GUI/OptionsSections/Languages.tscn" id="1"]
 [ext_resource type="PackedScene" path="res://addons/GameTemplate/GUI/OptionsSections/Controls.tscn" id="2"]
 [ext_resource type="PackedScene" uid="uid://ssfa3xrbdxx5" path="res://addons/GameTemplate/GUI/OptionsSections/General.tscn" id="3"]
 
@@ -10,13 +10,13 @@ extends Node
 
 func _ready()->void:
 	#show main section and hide controls
-	MenuEvent.connect(\"OptionsSignal\", on_show_options)
-	MenuEvent.Controls_val = false
+	MenuEvent.connect(\"Options\", on_show_options)
+	MenuEvent.Controls = false
 	$OptionsMenu/BG.visible = false
 
 func on_show_options(value:bool)->void:
 	$OptionsMenu/BG.visible = value
-	MenuEvent.Controls_val = false
+	MenuEvent.Controls = false
 "
 
 [sub_resource type="StyleBoxFlat" id="2"]

--- a/GameTemplate/addons/GameTemplate/Autoload/Options.tscn
+++ b/GameTemplate/addons/GameTemplate/Autoload/Options.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=6 format=3 uid="uid://mm7txw32xv4i"]
 
 [ext_resource type="PackedScene" uid="uid://dv20udv56ebyy" path="res://addons/GameTemplate/GUI/OptionsSections/Languages.tscn" id="1"]
-[ext_resource type="PackedScene" path="res://addons/GameTemplate/GUI/OptionsSections/Controls.tscn" id="2"]
+[ext_resource type="PackedScene" uid="uid://dovclayfphu6p" path="res://addons/GameTemplate/GUI/OptionsSections/Controls.tscn" id="2"]
 [ext_resource type="PackedScene" uid="uid://ssfa3xrbdxx5" path="res://addons/GameTemplate/GUI/OptionsSections/General.tscn" id="3"]
 
 [sub_resource type="GDScript" id="1"]

--- a/GameTemplate/addons/GameTemplate/Autoload/Pau302B.tmp
+++ b/GameTemplate/addons/GameTemplate/Autoload/Pau302B.tmp
@@ -1,6 +1,6 @@
-[gd_scene load_steps=4 format=3 uid="uid://cmux2dc14iiyr"]
+[gd_scene load_steps=4 format=3 uid="uid://bxmbwkg68m8ik"]
 
-[ext_resource type="PackedScene" uid="uid://dp81qs74tu3ba" path="res://addons/GameTemplate/GUI/Buttons/DefaultButton.tscn" id="1"]
+[ext_resource type="PackedScene" path="res://addons/GameTemplate/GUI/Buttons/DefaultButton.tscn" id="1"]
 
 [sub_resource type="GDScript" id="1"]
 script/source = "extends CanvasLayer
@@ -16,37 +16,37 @@ var can_show: = false
 var MainMenu: = 'res://MainMenu/MainMenu.tscn'		# MainMenu scene when in levels
 
 func _ready()->void:
-	MenuEvent.Paused_val = false
+	MenuEvent.Paused = false
 	
 	#Localization
-	SettingsLanguage.connect(\"ReTranslate\", retranslate)
-	resume.connect(\"pressed\", _on_Resume_pressed)
-	restart.connect(\"pressed\", _on_Restart_pressed)
-	options.connect(\"pressed\", _on_Options_pressed)
-	mainmenu.connect(\"pressed\", _on_MainMenu_pressed)
-	exit.connect(\"pressed\", _on_Exit_pressed)
+	SettingsLanguage.connect(\"ReTranslate\", Callable(self, \"retranslate\"))
+	resume.connect(\"pressed\", Callable(self, \"_on_Resume_pressed\"))
+	restart.connect(\"pressed\", Callable(self, \"_on_Restart_pressed\"))
+	options.connect(\"pressed\", Callable(self, \"_on_Options_pressed\"))
+	mainmenu.connect(\"pressed\", Callable(self, \"_on_MainMenu_pressed\"))
+	exit.connect(\"pressed\", Callable(self, \"_on_Exit_pressed\"))
 	retranslate()
 	
 
 func show_menu(value:bool)->void:
 	if !can_show:
 		return
-	MenuEvent.Paused_val = value
+	MenuEvent.Paused = value
 	$Control.visible = value
 	if value:
 		get_tree().get_nodes_in_group(\"Pause\")[0].grab_focus()
 
 
 func _on_Resume_pressed()->void:
-	show_menu(false)
 	Game.emit_signal(\"Resume\")
+	show_menu(false)
 
 func _on_Restart_pressed()->void:
-	show_menu(false)
 	Game.emit_signal(\"Restart\")
+	show_menu(false)
 
 func _on_Options_pressed()->void:
-	MenuEvent.Options_val = true
+	MenuEvent.Options = true
 
 func _on_MainMenu_pressed()->void:
 	Game.emit_signal(\"ChangeScene\", MainMenu)
@@ -62,6 +62,15 @@ func retranslate()->void:
 	options.text = tr(\"OPTIONS\")
 	mainmenu.text = tr(\"MAIN_MENU\")
 	exit.text = tr(\"EXIT\")
+
+
+
+
+
+
+
+
+
 "
 
 [sub_resource type="StyleBoxFlat" id="2"]
@@ -89,8 +98,6 @@ layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
 
 [node name="MarginContainer" type="MarginContainer" parent="Control"]
 layout_mode = 0

--- a/GameTemplate/addons/GameTemplate/Autoload/Pau49D0.tmp
+++ b/GameTemplate/addons/GameTemplate/Autoload/Pau49D0.tmp
@@ -1,6 +1,6 @@
 [gd_scene load_steps=4 format=3 uid="uid://cmux2dc14iiyr"]
 
-[ext_resource type="PackedScene" uid="uid://dp81qs74tu3ba" path="res://addons/GameTemplate/GUI/Buttons/DefaultButton.tscn" id="1"]
+[ext_resource type="PackedScene" path="res://addons/GameTemplate/GUI/Buttons/DefaultButton.tscn" id="1"]
 
 [sub_resource type="GDScript" id="1"]
 script/source = "extends CanvasLayer
@@ -16,15 +16,15 @@ var can_show: = false
 var MainMenu: = 'res://MainMenu/MainMenu.tscn'		# MainMenu scene when in levels
 
 func _ready()->void:
-	MenuEvent.Paused_val = false
+	MenuEvent.Paused = false
 	
 	#Localization
-	SettingsLanguage.connect(\"ReTranslate\", retranslate)
-	resume.connect(\"pressed\", _on_Resume_pressed)
-	restart.connect(\"pressed\", _on_Restart_pressed)
-	options.connect(\"pressed\", _on_Options_pressed)
-	mainmenu.connect(\"pressed\", _on_MainMenu_pressed)
-	exit.connect(\"pressed\", _on_Exit_pressed)
+	SettingsLanguage.connect(\"ReTranslate\", Callable(self, \"retranslate\"))
+	resume.connect(\"pressed\", Callable(self, \"_on_Resume_pressed\"))
+	restart.connect(\"pressed\", Callable(self, \"_on_Restart_pressed\"))
+	options.connect(\"pressed\", Callable(self, \"_on_Options_pressed\"))
+	mainmenu.connect(\"pressed\", Callable(self, \"_on_MainMenu_pressed\"))
+	exit.connect(\"pressed\", Callable(self, \"_on_Exit_pressed\"))
 	retranslate()
 	
 
@@ -38,12 +38,12 @@ func show_menu(value:bool)->void:
 
 
 func _on_Resume_pressed()->void:
-	show_menu(false)
 	Game.emit_signal(\"Resume\")
+	show_menu(false)
 
 func _on_Restart_pressed()->void:
-	show_menu(false)
 	Game.emit_signal(\"Restart\")
+	show_menu(false)
 
 func _on_Options_pressed()->void:
 	MenuEvent.Options_val = true

--- a/GameTemplate/addons/GameTemplate/Autoload/Pau4C5A.tmp
+++ b/GameTemplate/addons/GameTemplate/Autoload/Pau4C5A.tmp
@@ -1,6 +1,6 @@
-[gd_scene load_steps=4 format=3 uid="uid://cmux2dc14iiyr"]
+[gd_scene load_steps=4 format=3 uid="uid://66ssoyfgl3cv"]
 
-[ext_resource type="PackedScene" uid="uid://dp81qs74tu3ba" path="res://addons/GameTemplate/GUI/Buttons/DefaultButton.tscn" id="1"]
+[ext_resource type="PackedScene" path="res://addons/GameTemplate/GUI/Buttons/DefaultButton.tscn" id="1"]
 
 [sub_resource type="GDScript" id="1"]
 script/source = "extends CanvasLayer
@@ -16,37 +16,37 @@ var can_show: = false
 var MainMenu: = 'res://MainMenu/MainMenu.tscn'		# MainMenu scene when in levels
 
 func _ready()->void:
-	MenuEvent.Paused_val = false
+	MenuEvent.PausedSignal = false
 	
 	#Localization
-	SettingsLanguage.connect(\"ReTranslate\", retranslate)
-	resume.connect(\"pressed\", _on_Resume_pressed)
-	restart.connect(\"pressed\", _on_Restart_pressed)
-	options.connect(\"pressed\", _on_Options_pressed)
-	mainmenu.connect(\"pressed\", _on_MainMenu_pressed)
-	exit.connect(\"pressed\", _on_Exit_pressed)
+	SettingsLanguage.connect(\"ReTranslate\", Callable(self, \"retranslate\"))
+	resume.connect(\"pressed\", Callable(self, \"_on_Resume_pressed\"))
+	restart.connect(\"pressed\", Callable(self, \"_on_Restart_pressed\"))
+	options.connect(\"pressed\", Callable(self, \"_on_Options_pressed\"))
+	mainmenu.connect(\"pressed\", Callable(self, \"_on_MainMenu_pressed\"))
+	exit.connect(\"pressed\", Callable(self, \"_on_Exit_pressed\"))
 	retranslate()
 	
 
 func show_menu(value:bool)->void:
 	if !can_show:
 		return
-	MenuEvent.Paused_val = value
+	MenuEvent.Paused = value
 	$Control.visible = value
 	if value:
 		get_tree().get_nodes_in_group(\"Pause\")[0].grab_focus()
 
 
 func _on_Resume_pressed()->void:
-	show_menu(false)
 	Game.emit_signal(\"Resume\")
+	show_menu(false)
 
 func _on_Restart_pressed()->void:
-	show_menu(false)
 	Game.emit_signal(\"Restart\")
+	show_menu(false)
 
 func _on_Options_pressed()->void:
-	MenuEvent.Options_val = true
+	MenuEvent.Options = true
 
 func _on_MainMenu_pressed()->void:
 	Game.emit_signal(\"ChangeScene\", MainMenu)
@@ -89,8 +89,6 @@ layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
 
 [node name="MarginContainer" type="MarginContainer" parent="Control"]
 layout_mode = 0

--- a/GameTemplate/addons/GameTemplate/Autoload/Pau5329.tmp
+++ b/GameTemplate/addons/GameTemplate/Autoload/Pau5329.tmp
@@ -1,6 +1,6 @@
 [gd_scene load_steps=4 format=3 uid="uid://cmux2dc14iiyr"]
 
-[ext_resource type="PackedScene" uid="uid://dp81qs74tu3ba" path="res://addons/GameTemplate/GUI/Buttons/DefaultButton.tscn" id="1"]
+[ext_resource type="PackedScene" path="res://addons/GameTemplate/GUI/Buttons/DefaultButton.tscn" id="1"]
 
 [sub_resource type="GDScript" id="1"]
 script/source = "extends CanvasLayer
@@ -16,37 +16,37 @@ var can_show: = false
 var MainMenu: = 'res://MainMenu/MainMenu.tscn'		# MainMenu scene when in levels
 
 func _ready()->void:
-	MenuEvent.Paused_val = false
+	MenuEvent.PausedSignal = false
 	
 	#Localization
-	SettingsLanguage.connect(\"ReTranslate\", retranslate)
-	resume.connect(\"pressed\", _on_Resume_pressed)
-	restart.connect(\"pressed\", _on_Restart_pressed)
-	options.connect(\"pressed\", _on_Options_pressed)
-	mainmenu.connect(\"pressed\", _on_MainMenu_pressed)
-	exit.connect(\"pressed\", _on_Exit_pressed)
+	SettingsLanguage.connect(\"ReTranslate\", Callable(self, \"retranslate\"))
+	resume.connect(\"pressed\", Callable(self, \"_on_Resume_pressed\"))
+	restart.connect(\"pressed\", Callable(self, \"_on_Restart_pressed\"))
+	options.connect(\"pressed\", Callable(self, \"_on_Options_pressed\"))
+	mainmenu.connect(\"pressed\", Callable(self, \"_on_MainMenu_pressed\"))
+	exit.connect(\"pressed\", Callable(self, \"_on_Exit_pressed\"))
 	retranslate()
 	
 
 func show_menu(value:bool)->void:
 	if !can_show:
 		return
-	MenuEvent.Paused_val = value
+	MenuEvent.PausedSignal = value
 	$Control.visible = value
 	if value:
 		get_tree().get_nodes_in_group(\"Pause\")[0].grab_focus()
 
 
 func _on_Resume_pressed()->void:
-	show_menu(false)
 	Game.emit_signal(\"Resume\")
+	show_menu(false)
 
 func _on_Restart_pressed()->void:
-	show_menu(false)
 	Game.emit_signal(\"Restart\")
+	show_menu(false)
 
 func _on_Options_pressed()->void:
-	MenuEvent.Options_val = true
+	MenuEvent.OptionsSignal = true
 
 func _on_MainMenu_pressed()->void:
 	Game.emit_signal(\"ChangeScene\", MainMenu)
@@ -89,8 +89,6 @@ layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
 
 [node name="MarginContainer" type="MarginContainer" parent="Control"]
 layout_mode = 0

--- a/GameTemplate/addons/GameTemplate/Autoload/Pau66F.tmp
+++ b/GameTemplate/addons/GameTemplate/Autoload/Pau66F.tmp
@@ -1,6 +1,6 @@
 [gd_scene load_steps=4 format=3 uid="uid://cmux2dc14iiyr"]
 
-[ext_resource type="PackedScene" uid="uid://dp81qs74tu3ba" path="res://addons/GameTemplate/GUI/Buttons/DefaultButton.tscn" id="1"]
+[ext_resource type="PackedScene" path="res://addons/GameTemplate/GUI/Buttons/DefaultButton.tscn" id="1"]
 
 [sub_resource type="GDScript" id="1"]
 script/source = "extends CanvasLayer
@@ -16,37 +16,37 @@ var can_show: = false
 var MainMenu: = 'res://MainMenu/MainMenu.tscn'		# MainMenu scene when in levels
 
 func _ready()->void:
-	MenuEvent.Paused_val = false
+	MenuEvent.Paused = false
 	
 	#Localization
-	SettingsLanguage.connect(\"ReTranslate\", retranslate)
-	resume.connect(\"pressed\", _on_Resume_pressed)
-	restart.connect(\"pressed\", _on_Restart_pressed)
-	options.connect(\"pressed\", _on_Options_pressed)
-	mainmenu.connect(\"pressed\", _on_MainMenu_pressed)
-	exit.connect(\"pressed\", _on_Exit_pressed)
+	SettingsLanguage.connect(\"ReTranslate\", Callable(self, \"retranslate\"))
+	resume.connect(\"pressed\", Callable(self, \"_on_Resume_pressed\"))
+	restart.connect(\"pressed\", Callable(self, \"_on_Restart_pressed\"))
+	options.connect(\"pressed\", Callable(self, \"_on_Options_pressed\"))
+	mainmenu.connect(\"pressed\", Callable(self, \"_on_MainMenu_pressed\"))
+	exit.connect(\"pressed\", Callable(self, \"_on_Exit_pressed\"))
 	retranslate()
 	
 
 func show_menu(value:bool)->void:
 	if !can_show:
 		return
-	MenuEvent.Paused_val = value
+	MenuEvent.PausedSignal = value
 	$Control.visible = value
 	if value:
 		get_tree().get_nodes_in_group(\"Pause\")[0].grab_focus()
 
 
 func _on_Resume_pressed()->void:
-	show_menu(false)
 	Game.emit_signal(\"Resume\")
+	show_menu(false)
 
 func _on_Restart_pressed()->void:
-	show_menu(false)
 	Game.emit_signal(\"Restart\")
+	show_menu(false)
 
 func _on_Options_pressed()->void:
-	MenuEvent.Options_val = true
+	MenuEvent.OptionsSignal = true
 
 func _on_MainMenu_pressed()->void:
 	Game.emit_signal(\"ChangeScene\", MainMenu)

--- a/GameTemplate/addons/GameTemplate/Autoload/Pau7432.tmp
+++ b/GameTemplate/addons/GameTemplate/Autoload/Pau7432.tmp
@@ -1,6 +1,6 @@
 [gd_scene load_steps=4 format=3 uid="uid://cmux2dc14iiyr"]
 
-[ext_resource type="PackedScene" uid="uid://dp81qs74tu3ba" path="res://addons/GameTemplate/GUI/Buttons/DefaultButton.tscn" id="1"]
+[ext_resource type="PackedScene" path="res://addons/GameTemplate/GUI/Buttons/DefaultButton.tscn" id="1"]
 
 [sub_resource type="GDScript" id="1"]
 script/source = "extends CanvasLayer
@@ -16,37 +16,37 @@ var can_show: = false
 var MainMenu: = 'res://MainMenu/MainMenu.tscn'		# MainMenu scene when in levels
 
 func _ready()->void:
-	MenuEvent.Paused_val = false
+	MenuEvent.PausedSignal = false
 	
 	#Localization
-	SettingsLanguage.connect(\"ReTranslate\", retranslate)
-	resume.connect(\"pressed\", _on_Resume_pressed)
-	restart.connect(\"pressed\", _on_Restart_pressed)
-	options.connect(\"pressed\", _on_Options_pressed)
-	mainmenu.connect(\"pressed\", _on_MainMenu_pressed)
-	exit.connect(\"pressed\", _on_Exit_pressed)
+	SettingsLanguage.connect(\"ReTranslate\", Callable(self, \"retranslate\"))
+	resume.connect(\"pressed\", Callable(self, \"_on_Resume_pressed\"))
+	restart.connect(\"pressed\", Callable(self, \"_on_Restart_pressed\"))
+	options.connect(\"pressed\", Callable(self, \"_on_Options_pressed\"))
+	mainmenu.connect(\"pressed\", Callable(self, \"_on_MainMenu_pressed\"))
+	exit.connect(\"pressed\", Callable(self, \"_on_Exit_pressed\"))
 	retranslate()
 	
 
 func show_menu(value:bool)->void:
 	if !can_show:
 		return
-	MenuEvent.Paused_val = value
+	MenuEvent.PausedSignal = value
 	$Control.visible = value
 	if value:
 		get_tree().get_nodes_in_group(\"Pause\")[0].grab_focus()
 
 
 func _on_Resume_pressed()->void:
-	show_menu(false)
 	Game.emit_signal(\"Resume\")
+	show_menu(false)
 
 func _on_Restart_pressed()->void:
-	show_menu(false)
 	Game.emit_signal(\"Restart\")
+	show_menu(false)
 
 func _on_Options_pressed()->void:
-	MenuEvent.Options_val = true
+	MenuEvent.Options = true
 
 func _on_MainMenu_pressed()->void:
 	Game.emit_signal(\"ChangeScene\", MainMenu)
@@ -89,8 +89,6 @@ layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
 
 [node name="MarginContainer" type="MarginContainer" parent="Control"]
 layout_mode = 0

--- a/GameTemplate/addons/GameTemplate/Autoload/PauD599.tmp
+++ b/GameTemplate/addons/GameTemplate/Autoload/PauD599.tmp
@@ -1,6 +1,6 @@
 [gd_scene load_steps=4 format=3 uid="uid://cmux2dc14iiyr"]
 
-[ext_resource type="PackedScene" uid="uid://dp81qs74tu3ba" path="res://addons/GameTemplate/GUI/Buttons/DefaultButton.tscn" id="1"]
+[ext_resource type="PackedScene" path="res://addons/GameTemplate/GUI/Buttons/DefaultButton.tscn" id="1"]
 
 [sub_resource type="GDScript" id="1"]
 script/source = "extends CanvasLayer
@@ -16,37 +16,37 @@ var can_show: = false
 var MainMenu: = 'res://MainMenu/MainMenu.tscn'		# MainMenu scene when in levels
 
 func _ready()->void:
-	MenuEvent.Paused_val = false
+	MenuEvent.PausedSignal = false
 	
 	#Localization
-	SettingsLanguage.connect(\"ReTranslate\", retranslate)
-	resume.connect(\"pressed\", _on_Resume_pressed)
-	restart.connect(\"pressed\", _on_Restart_pressed)
-	options.connect(\"pressed\", _on_Options_pressed)
-	mainmenu.connect(\"pressed\", _on_MainMenu_pressed)
-	exit.connect(\"pressed\", _on_Exit_pressed)
+	SettingsLanguage.connect(\"ReTranslate\", Callable(self, \"retranslate\"))
+	resume.connect(\"pressed\", Callable(self, \"_on_Resume_pressed\"))
+	restart.connect(\"pressed\", Callable(self, \"_on_Restart_pressed\"))
+	options.connect(\"pressed\", Callable(self, \"_on_Options_pressed\"))
+	mainmenu.connect(\"pressed\", Callable(self, \"_on_MainMenu_pressed\"))
+	exit.connect(\"pressed\", Callable(self, \"_on_Exit_pressed\"))
 	retranslate()
 	
 
 func show_menu(value:bool)->void:
 	if !can_show:
 		return
-	MenuEvent.Paused_val = value
+	MenuEvent.PausedSignal = value
 	$Control.visible = value
 	if value:
 		get_tree().get_nodes_in_group(\"Pause\")[0].grab_focus()
 
 
 func _on_Resume_pressed()->void:
-	show_menu(false)
 	Game.emit_signal(\"Resume\")
+	show_menu(false)
 
 func _on_Restart_pressed()->void:
-	show_menu(false)
 	Game.emit_signal(\"Restart\")
+	show_menu(false)
 
 func _on_Options_pressed()->void:
-	MenuEvent.Options_val = true
+	MenuEvent.OptionsSignal = true
 
 func _on_MainMenu_pressed()->void:
 	Game.emit_signal(\"ChangeScene\", MainMenu)
@@ -89,8 +89,6 @@ layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
 
 [node name="MarginContainer" type="MarginContainer" parent="Control"]
 layout_mode = 0

--- a/GameTemplate/addons/GameTemplate/Autoload/PauEBD4.tmp
+++ b/GameTemplate/addons/GameTemplate/Autoload/PauEBD4.tmp
@@ -1,6 +1,6 @@
 [gd_scene load_steps=4 format=3 uid="uid://cmux2dc14iiyr"]
 
-[ext_resource type="PackedScene" uid="uid://dp81qs74tu3ba" path="res://addons/GameTemplate/GUI/Buttons/DefaultButton.tscn" id="1"]
+[ext_resource type="PackedScene" path="res://addons/GameTemplate/GUI/Buttons/DefaultButton.tscn" id="1"]
 
 [sub_resource type="GDScript" id="1"]
 script/source = "extends CanvasLayer
@@ -16,37 +16,37 @@ var can_show: = false
 var MainMenu: = 'res://MainMenu/MainMenu.tscn'		# MainMenu scene when in levels
 
 func _ready()->void:
-	MenuEvent.Paused_val = false
+	MenuEvent.PausedSignal = false
 	
 	#Localization
-	SettingsLanguage.connect(\"ReTranslate\", retranslate)
-	resume.connect(\"pressed\", _on_Resume_pressed)
-	restart.connect(\"pressed\", _on_Restart_pressed)
-	options.connect(\"pressed\", _on_Options_pressed)
-	mainmenu.connect(\"pressed\", _on_MainMenu_pressed)
-	exit.connect(\"pressed\", _on_Exit_pressed)
+	SettingsLanguage.connect(\"ReTranslate\", Callable(self, \"retranslate\"))
+	resume.connect(\"pressed\", Callable(self, \"_on_Resume_pressed\"))
+	restart.connect(\"pressed\", Callable(self, \"_on_Restart_pressed\"))
+	options.connect(\"pressed\", Callable(self, \"_on_Options_pressed\"))
+	mainmenu.connect(\"pressed\", Callable(self, \"_on_MainMenu_pressed\"))
+	exit.connect(\"pressed\", Callable(self, \"_on_Exit_pressed\"))
 	retranslate()
 	
 
 func show_menu(value:bool)->void:
 	if !can_show:
 		return
-	MenuEvent.Paused_val = value
+	MenuEvent.PausedSignal = value
 	$Control.visible = value
 	if value:
 		get_tree().get_nodes_in_group(\"Pause\")[0].grab_focus()
 
 
 func _on_Resume_pressed()->void:
-	show_menu(false)
 	Game.emit_signal(\"Resume\")
+	show_menu(false)
 
 func _on_Restart_pressed()->void:
-	show_menu(false)
 	Game.emit_signal(\"Restart\")
+	show_menu(false)
 
 func _on_Options_pressed()->void:
-	MenuEvent.Options_val = true
+	MenuEvent.OptionsSignal = true
 
 func _on_MainMenu_pressed()->void:
 	Game.emit_signal(\"ChangeScene\", MainMenu)
@@ -89,8 +89,6 @@ layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
 
 [node name="MarginContainer" type="MarginContainer" parent="Control"]
 layout_mode = 0

--- a/GameTemplate/addons/GameTemplate/Autoload/PauF8A9.tmp
+++ b/GameTemplate/addons/GameTemplate/Autoload/PauF8A9.tmp
@@ -1,6 +1,6 @@
 [gd_scene load_steps=4 format=3 uid="uid://cmux2dc14iiyr"]
 
-[ext_resource type="PackedScene" uid="uid://dp81qs74tu3ba" path="res://addons/GameTemplate/GUI/Buttons/DefaultButton.tscn" id="1"]
+[ext_resource type="PackedScene" path="res://addons/GameTemplate/GUI/Buttons/DefaultButton.tscn" id="1"]
 
 [sub_resource type="GDScript" id="1"]
 script/source = "extends CanvasLayer
@@ -16,37 +16,37 @@ var can_show: = false
 var MainMenu: = 'res://MainMenu/MainMenu.tscn'		# MainMenu scene when in levels
 
 func _ready()->void:
-	MenuEvent.Paused_val = false
+	MenuEvent.Paused = false
 	
 	#Localization
-	SettingsLanguage.connect(\"ReTranslate\", retranslate)
-	resume.connect(\"pressed\", _on_Resume_pressed)
-	restart.connect(\"pressed\", _on_Restart_pressed)
-	options.connect(\"pressed\", _on_Options_pressed)
-	mainmenu.connect(\"pressed\", _on_MainMenu_pressed)
-	exit.connect(\"pressed\", _on_Exit_pressed)
+	SettingsLanguage.connect(\"ReTranslate\", Callable(self, \"retranslate\"))
+	resume.connect(\"pressed\", Callable(self, \"_on_Resume_pressed\"))
+	restart.connect(\"pressed\", Callable(self, \"_on_Restart_pressed\"))
+	options.connect(\"pressed\", Callable(self, \"_on_Options_pressed\"))
+	mainmenu.connect(\"pressed\", Callable(self, \"_on_MainMenu_pressed\"))
+	exit.connect(\"pressed\", Callable(self, \"_on_Exit_pressed\"))
 	retranslate()
 	
 
 func show_menu(value:bool)->void:
 	if !can_show:
 		return
-	MenuEvent.Paused_val = value
+	MenuEvent.PausedSignal = value
 	$Control.visible = value
 	if value:
 		get_tree().get_nodes_in_group(\"Pause\")[0].grab_focus()
 
 
 func _on_Resume_pressed()->void:
-	show_menu(false)
 	Game.emit_signal(\"Resume\")
+	show_menu(false)
 
 func _on_Restart_pressed()->void:
-	show_menu(false)
 	Game.emit_signal(\"Restart\")
+	show_menu(false)
 
 func _on_Options_pressed()->void:
-	MenuEvent.Options_val = true
+	MenuEvent.OptionsSignal = true
 
 func _on_MainMenu_pressed()->void:
 	Game.emit_signal(\"ChangeScene\", MainMenu)

--- a/GameTemplate/addons/GameTemplate/Autoload/PauseMenu.tscn
+++ b/GameTemplate/addons/GameTemplate/Autoload/PauseMenu.tscn
@@ -91,11 +91,16 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+size_flags_horizontal = 6
+size_flags_vertical = 6
 
 [node name="MarginContainer" type="MarginContainer" parent="Control"]
-layout_mode = 0
+layout_mode = 1
+anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
 theme_override_constants/margin_left = 60
 theme_override_constants/margin_top = 30
 theme_override_constants/margin_right = 60
@@ -106,9 +111,12 @@ layout_mode = 2
 theme_override_styles/panel = SubResource("2")
 
 [node name="MarginContainer" type="MarginContainer" parent="Control/MarginContainer/Panel"]
-layout_mode = 0
+layout_mode = 1
+anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
 theme_override_constants/margin_left = 16
 theme_override_constants/margin_top = 16
 theme_override_constants/margin_right = 16

--- a/GameTemplate/addons/GameTemplate/Autoload/Scr71E9.tmp
+++ b/GameTemplate/addons/GameTemplate/Autoload/Scr71E9.tmp
@@ -26,21 +26,13 @@ func set_state(value:fade_type)->void:
 	state = value
 	match state:
 		fade_type.IN:
-			var newTween = get_tree().create_tween()
-			newTween.tween_property(colorRect, \"modulate\", Color(0,0,0,0), 0.5)
-			newTween.set_trans(Tween.TRANS_LINEAR)
-			newTween.set_ease(Tween.EASE_IN)
-			newTween.tween_callback(tween_completed)
-			newTween.play()
-			await newTween.finished
+			Tween \\
+			.interpolate_value(percent, 1.0, 0.0, 0.5, Tween.TRANS_LINEAR, Tween.EASE_IN).start() \\
+			.connect(\"tween_all_completed\", tween_completed)
 		fade_type.OUT:
-			var newTween = get_tree().create_tween()
-			newTween.tween_property(colorRect, \"modulate\", Color(0,0,0,1), 0.5)
-			newTween.set_trans(Tween.TRANS_LINEAR)
-			newTween.set_ease(Tween.EASE_OUT)
-			newTween.tween_callback(tween_completed)
-			newTween.play()
-			await newTween.finished
+			Tween \\
+				.interpolate_value(percent, 0.0, 1.0, 0.5, Tween.TRANS_LINEAR, Tween.EASE_IN).start() \\
+				.connect(\"tween_all_completed\", tween_completed)
 
 func _ready()->void:
 	colorRect.modulate.a = percent

--- a/GameTemplate/addons/GameTemplate/Autoload/ScrB8B6.tmp
+++ b/GameTemplate/addons/GameTemplate/Autoload/ScrB8B6.tmp
@@ -5,13 +5,8 @@ script/source = "extends Node
 
 signal fade_complete
 
-enum fade_type {
-	IDLE, 
-	BLACK, 
-	IN, 
-	OUT
-}
-var state: = fade_type.IDLE: set = set_state
+enum {IDLE, BLACK, IN, OUT}
+var state: = IDLE: set = set_state
 
 @onready var colorRect: = $Fade_layer/ColorRect
 
@@ -22,35 +17,28 @@ func set_percent(value:float)->void:
 	#Fade logic
 	colorRect.modulate.a = percent
 
-func set_state(value:fade_type)->void:
+func set_state(value:int)->void:
 	state = value
 	match state:
-		fade_type.IN:
-			var newTween = get_tree().create_tween()
-			newTween.tween_property(colorRect, \"modulate\", Color(0,0,0,0), 0.5)
-			newTween.set_trans(Tween.TRANS_LINEAR)
-			newTween.set_ease(Tween.EASE_IN)
-			newTween.tween_callback(tween_completed)
-			newTween.play()
-			await newTween.finished
-		fade_type.OUT:
-			var newTween = get_tree().create_tween()
-			newTween.tween_property(colorRect, \"modulate\", Color(0,0,0,1), 0.5)
-			newTween.set_trans(Tween.TRANS_LINEAR)
-			newTween.set_ease(Tween.EASE_OUT)
-			newTween.tween_callback(tween_completed)
-			newTween.play()
-			await newTween.finished
+		IN:
+			get_tree().create_tween() \\
+			.interpolate_value(percent, 1.0, 0.0, 0.5, Tween.TRANS_LINEAR, Tween.EASE_IN).start() \\
+			.connect(\"tween_all_completed\", tween_completed)
+		OUT:
+			get_tree().create_tween() \\
+				.interpolate_value(percent, 0.0, 1.0, 0.5, Tween.TRANS_LINEAR, Tween.EASE_IN).start() \\
+				.connect(\"tween_all_completed\", tween_completed)
 
 func _ready()->void:
 	colorRect.modulate.a = percent
+	tween.connect(\"tween_all_completed\", Callable(self, \"tween_completed\"))
 
 func tween_completed()->void:
 	match state:
-		fade_type.IN:
-			state = fade_type.IDLE
-		fade_type.OUT:
-			state = fade_type.BLACK
+		IN:
+			state = IDLE
+		OUT:
+			state = BLACK
 	emit_signal(\"fade_complete\")
 "
 

--- a/GameTemplate/addons/GameTemplate/Autoload/ScreenFade.tscn
+++ b/GameTemplate/addons/GameTemplate/Autoload/ScreenFade.tscn
@@ -3,6 +3,7 @@
 [sub_resource type="GDScript" id="1"]
 script/source = "extends Node
 
+@warning_ignore(\"unused_signal\")
 signal fade_complete
 
 enum fade_type {

--- a/GameTemplate/addons/GameTemplate/Autoload/Settings.gd
+++ b/GameTemplate/addons/GameTemplate/Autoload/Settings.gd
@@ -3,7 +3,7 @@ extends Node
 #OS
 var HTML5:bool = false
 
-func _ready()->void:				
+func _ready()->void:	
 	if OS.get_name() == "HTML5":
 		HTML5 = true
 	SettingsLanguage.add_translations()											#TO-DO need a way to add translations to project through the plugin

--- a/GameTemplate/addons/GameTemplate/Autoload/Settings.gd
+++ b/GameTemplate/addons/GameTemplate/Autoload/Settings.gd
@@ -4,7 +4,7 @@ extends Node
 var HTML5:bool = false
 
 func _ready()->void:	
-	if OS.get_name() == "HTML5":
+	if OS.has_feature('web'):
 		HTML5 = true
 	SettingsLanguage.add_translations()											#TO-DO need a way to add translations to project through the plugin
 	SettingsResolution.get_resolution()

--- a/GameTemplate/addons/GameTemplate/Autoload/Settings.gd
+++ b/GameTemplate/addons/GameTemplate/Autoload/Settings.gd
@@ -12,4 +12,3 @@ func _ready()->void:
 		SettingsControls.default_controls()
 	SettingsAudio.get_volumes()
 	#SettingsSaveLoad.save_settings()											#Call this method to trigger Settings saving
-

--- a/GameTemplate/addons/GameTemplate/Autoload/SettingsAudio.gd
+++ b/GameTemplate/addons/GameTemplate/Autoload/SettingsAudio.gd
@@ -2,9 +2,9 @@ extends Node
 
 
 #AUDIO
-var VolumeMaster:float = 0.0 setget set_volume_master
-var VolumeMusic:float = 0.0 setget set_volume_music
-var VolumeSFX:float = 0.0 setget set_volume_sfx
+var VolumeMaster:float = 0.0: set = set_volume_master
+var VolumeMusic:float = 0.0: set = set_volume_music
+var VolumeSFX:float = 0.0: set = set_volume_sfx
 const VolumeRange:float = 24.0 + 80.0
 
 func _ready()->void:
@@ -12,9 +12,9 @@ func _ready()->void:
 
 #AUDIO
 func get_volumes()->void:
-	var Master:float	= db2linear(AudioServer.get_bus_volume_db(AudioServer.get_bus_index("Master")))
-	var Music:float 	= db2linear(AudioServer.get_bus_volume_db(AudioServer.get_bus_index("Music")))
-	var SFX:float 		= db2linear(AudioServer.get_bus_volume_db(AudioServer.get_bus_index("SFX")))
+	var Master:float	= db_to_linear(AudioServer.get_bus_volume_db(AudioServer.get_bus_index("Master")))
+	var Music:float 	= db_to_linear(AudioServer.get_bus_volume_db(AudioServer.get_bus_index("Music")))
+	var SFX:float 		= db_to_linear(AudioServer.get_bus_volume_db(AudioServer.get_bus_index("SFX")))
 	
 	set_volume_master(Master)
 	set_volume_music(Music)
@@ -22,15 +22,15 @@ func get_volumes()->void:
 
 func set_volume_master(volume:float)->void:
 	VolumeMaster = volume
-	AudioServer.set_bus_volume_db(AudioServer.get_bus_index("Master"), linear2db(VolumeMaster))
+	AudioServer.set_bus_volume_db(AudioServer.get_bus_index("Master"), linear_to_db(VolumeMaster))
 
 func set_volume_music(volume:float)->void:
 	VolumeMusic = volume
-	AudioServer.set_bus_volume_db(AudioServer.get_bus_index("Music"), linear2db(VolumeMusic))
+	AudioServer.set_bus_volume_db(AudioServer.get_bus_index("Music"), linear_to_db(VolumeMusic))
 
 func set_volume_sfx(volume:float)->void:
 	VolumeSFX = volume
-	AudioServer.set_bus_volume_db(AudioServer.get_bus_index("SFX"), linear2db(VolumeSFX))
+	AudioServer.set_bus_volume_db(AudioServer.get_bus_index("SFX"), linear_to_db(VolumeSFX))
 
 
 #SAVING AUDIO

--- a/GameTemplate/addons/GameTemplate/Autoload/SettingsControls.gd
+++ b/GameTemplate/addons/GameTemplate/Autoload/SettingsControls.gd
@@ -12,13 +12,13 @@ var ActionControls:Dictionary = {}
 #	set_actions_info()
 
 func default_controls()->void:	#Reset to project settings controls
-	InputMap.load_from_globals()
+	InputMap.load_from_project_settings()
 	set_actions_info()
 
 func set_actions_info()->void:
 	ActionControls.clear()
 	for Action in Actions:
-		var ActionList:Array = InputMap.get_action_list(Action) #associated controlls to the action
+		var ActionList:Array = InputMap.action_get_events(Action) #associated controlls to the action
 		ActionControls[Action] = ActionList
 
 func print_events_list(ActionList:Array)->void:
@@ -43,7 +43,7 @@ func get_button_data(event)->Dictionary:
 	var button_data:Dictionary = {}
 	if event is InputEventKey:
 		button_data["EventType"] = "InputEventKey"
-		button_data["scancode"] = event.scancode
+		button_data["keycode"] = event.keycode
 	if event is InputEventJoypadButton:
 		button_data["EventType"] = "InputEventJoypadButton"
 		button_data["device"] = event.device
@@ -74,7 +74,7 @@ func set_button_data(button:Dictionary)->InputEvent:
 	var NewEvent:InputEvent
 	if button.EventType == "InputEventKey":
 		NewEvent = InputEventKey.new()
-		NewEvent.scancode = button.scancode
+		NewEvent.keycode = button.keycode
 	if button.EventType == "InputEventJoypadButton":
 		NewEvent = InputEventJoypadButton.new()
 		NewEvent.device = button.device
@@ -91,17 +91,3 @@ func set_InputMap()->void:
 		InputMap.action_erase_events(action_name)
 		for event in ActionControls[action_name]:
 			InputMap.action_add_event(action_name, event)
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/GameTemplate/addons/GameTemplate/Autoload/SettingsLanguage.gd
+++ b/GameTemplate/addons/GameTemplate/Autoload/SettingsLanguage.gd
@@ -16,7 +16,7 @@ var translations: = [
 	preload("res://addons/GameTemplate/Localization/Localization.tr.translation"),
 	preload("res://addons/GameTemplate/Localization/Localization.ru.translation")
 ]
-onready var Language:String = TranslationServer.get_locale() setget set_language
+@onready var Language:String = TranslationServer.get_locale(): set = set_language
 var Language_dictionary:Dictionary = {EN = "en", DE = "de", ES = "es", FR = "fr", SE = "sv_SE", BR = "pt_BR", LV = "lv", IT = "it", TR = "tr", RU = "ru"}
 var Language_list:Array = Language_dictionary.keys()
 

--- a/GameTemplate/addons/GameTemplate/Autoload/SettingsResolution.gd
+++ b/GameTemplate/addons/GameTemplate/Autoload/SettingsResolution.gd
@@ -25,7 +25,8 @@ func set_fullscreen(value:bool)->void:
 
 func set_borderless(value:bool)->void:
 	Borderless = value
-	get_window().borderless  = value
+	get_window().borderless = value
+	set_scale(Scale)
 
 func get_resolution()->void:
 	View = get_viewport()

--- a/GameTemplate/addons/GameTemplate/Autoload/SettingsResolution.gd
+++ b/GameTemplate/addons/GameTemplate/Autoload/SettingsResolution.gd
@@ -3,51 +3,50 @@ extends Node
 signal Resized
 
 #SCREEN
-var Fullscreen = false setget set_fullscreen
-var Borderless = false setget set_borderless
-var View:Viewport
+var Fullscreen = false
+var Borderless = false
+var View:Window
 var ViewRect2:Rect2
-var GameResolution:Vector2
 var WindowResolution:Vector2
+var GameResolution:Vector2
 var ScreenResolution:Vector2
 var ScreenAspectRatio:float
-var Scale:int = 3 setget set_scale				#Default scale multiple
+var Scale:int = 3: set = set_scale
 var MaxScale:int
 
 #RESOLUTION
 func set_fullscreen(value:bool)->void:
 	Fullscreen = value
-	OS.window_fullscreen = value
+	get_window().mode = Window.MODE_EXCLUSIVE_FULLSCREEN if (value) else Window.MODE_WINDOWED
 	if value:
 		set_scale(MaxScale)
 	else:
-		OS.center_window()
-		set_scale(OS.window_size.x/GameResolution.x)
+		set_scale(Scale - 1)
 
 func set_borderless(value:bool)->void:
 	Borderless = value
-	OS.window_borderless  = value
+	get_window().borderless  = value
 
 func get_resolution()->void:
 	View = get_viewport()
 	ViewRect2 = View.get_visible_rect()
 	GameResolution = ViewRect2.size
 	
-	WindowResolution = OS.window_size
-	ScreenResolution = OS.get_screen_size(OS.current_screen)
+	WindowResolution = DisplayServer.screen_get_size()
+	ScreenResolution = DisplayServer.screen_get_size()
 	ScreenAspectRatio = ScreenResolution.x/ScreenResolution.y
-	MaxScale = ceil(ScreenResolution.y/ GameResolution.y)
+	MaxScale = ceil(ScreenResolution.y / GameResolution.y)
 
 func set_scale(value:int)->void:
 	Scale = clamp(value, 1, MaxScale)
 	if Scale >= MaxScale:
-		OS.window_fullscreen = true
+		get_window().mode = Window.MODE_EXCLUSIVE_FULLSCREEN if (true) else Window.MODE_WINDOWED
 		Fullscreen = true
 	else:
-		OS.window_fullscreen = false
+		get_window().mode = Window.MODE_EXCLUSIVE_FULLSCREEN if (false) else Window.MODE_WINDOWED
 		Fullscreen = false
-		OS.window_size = GameResolution * Scale
-		OS.center_window()
+		get_window().size = GameResolution * Scale
+		get_window().move_to_center()
 	get_resolution()
 	emit_signal("Resized")
 

--- a/GameTemplate/addons/GameTemplate/Autoload/SettingsResolution.gd
+++ b/GameTemplate/addons/GameTemplate/Autoload/SettingsResolution.gd
@@ -11,6 +11,8 @@ var WindowResolution:Vector2
 var GameResolution:Vector2
 var ScreenResolution:Vector2
 var ScreenAspectRatio:float
+var WindowAspectRatio:float
+
 var Scale:int = 3: set = set_scale
 var MaxScale:int
 
@@ -33,10 +35,13 @@ func get_resolution()->void:
 	ViewRect2 = View.get_visible_rect()
 	GameResolution = ViewRect2.size
 	
-	WindowResolution = DisplayServer.screen_get_size()
+	WindowResolution = get_window().get_visible_rect().size
 	ScreenResolution = DisplayServer.screen_get_size()
-	ScreenAspectRatio = ScreenResolution.x/ScreenResolution.y
-	MaxScale = ceil(ScreenResolution.y / GameResolution.y)
+	if OS.has_feature("web"):
+		ScreenAspectRatio = WindowResolution.x/WindowResolution.y
+	else:
+		MaxScale = ceil(ScreenResolution.y / GameResolution.y)
+
 
 func set_scale(value:int)->void:
 	Scale = clamp(value, 1, MaxScale)
@@ -47,8 +52,8 @@ func set_scale(value:int)->void:
 		get_window().mode = Window.MODE_EXCLUSIVE_FULLSCREEN if (false) else Window.MODE_WINDOWED
 		Fullscreen = false
 		get_window().size = GameResolution * Scale
-		get_window().move_to_center()
 	get_resolution()
+	get_window().move_to_center()
 	emit_signal("Resized")
 
 

--- a/GameTemplate/addons/GameTemplate/GUI/BindingPopup/Popup.gd
+++ b/GameTemplate/addons/GameTemplate/GUI/BindingPopup/Popup.gd
@@ -19,7 +19,7 @@ func receive_input()->void:
 func receive_focus()->void:
 	get_tree().get_nodes_in_group("ContainerFocus")[0].call_deferred("grab_focus")
 
-func _unhandled_input(event: InputEvent) -> void:
+func _input(event: InputEvent) -> void:
 	if !event is InputEventKey && !event is InputEventJoypadButton && !event is InputEventJoypadMotion:
 		return #only continue if one of those
 	if !event.is_pressed():

--- a/GameTemplate/addons/GameTemplate/GUI/BindingPopup/Popup.gd
+++ b/GameTemplate/addons/GameTemplate/GUI/BindingPopup/Popup.gd
@@ -5,12 +5,12 @@ signal NewControl
 var NewEvent:InputEvent
 
 func _ready()->void:
-	popup_exclusive = true
+	exclusive = true
 	set_process_input(false)
-	connect("about_to_show", self, "receive_input")
-	connect("popup_hide", self, "receive_focus")
+	connect("about_to_popup", receive_input)
+	connect("popup_hide", receive_focus)
 	#Localization
-	SettingsLanguage.connect("ReTranslate", self, "retranslate")
+	SettingsLanguage.connect("ReTranslate", retranslate)
 	retranslate()
 
 func receive_input()->void:
@@ -19,7 +19,7 @@ func receive_input()->void:
 func receive_focus()->void:
 	get_tree().get_nodes_in_group("ContainerFocus")[0].call_deferred("grab_focus")
 
-func _input(event)->void:
+func _unhandled_input(event: InputEvent) -> void:
 	if !event is InputEventKey && !event is InputEventJoypadButton && !event is InputEventJoypadMotion:
 		return #only continue if one of those
 	if !event.is_pressed():
@@ -32,4 +32,4 @@ func _input(event)->void:
 
 #Localization
 func retranslate()->void:
-	find_node("Message").text = tr("USE_NEW_CONTROLS")
+	find_child("Message").text = tr("USE_NEW_CONTROLS")

--- a/GameTemplate/addons/GameTemplate/GUI/BindingPopup/Popup.tscn
+++ b/GameTemplate/addons/GameTemplate/GUI/BindingPopup/Popup.tscn
@@ -1,77 +1,68 @@
-[gd_scene load_steps=5 format=2]
+[gd_scene load_steps=5 format=3 uid="uid://de226x33vcwm8"]
 
-[ext_resource path="res://addons/GameTemplate/GUI/BindingPopup/Popup.gd" type="Script" id=1]
-[ext_resource path="res://addons/GameTemplate/Assets/Fonts/pixellocale_8.tres" type="FontFile" id=2]
+[ext_resource type="Script" path="res://addons/GameTemplate/GUI/BindingPopup/Popup.gd" id="1"]
+[ext_resource type="FontFile" path="res://addons/GameTemplate/Assets/Fonts/pixellocale_8.tres" id="2"]
 
-[sub_resource type="StyleBoxFlat" id=1]
-bg_color = Color( 0.0941176, 0.0784314, 0.145098, 1 )
+[sub_resource type="StyleBoxFlat" id="1"]
+bg_color = Color(0.0941176, 0.0784314, 0.145098, 1)
 border_width_left = 1
 border_width_top = 1
 border_width_right = 1
 border_width_bottom = 1
-border_color = Color( 1, 1, 1, 1 )
+border_color = Color(1, 1, 1, 1)
 anti_aliasing = false
 
-[sub_resource type="StyleBoxEmpty" id=2]
+[sub_resource type="StyleBoxEmpty" id="2"]
 
 [node name="Popup" type="Popup"]
-size_flags_horizontal = 3
-script = ExtResource( 1 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
+initial_position = 1
+size = Vector2i(300, 100)
+script = ExtResource("1")
 
-[node name="MarginContainer2" type="MarginContainer" parent="."]
-offset_left = -20.0
-offset_right = 340.0
-offset_bottom = 180.0
-size_flags_horizontal = 3
-size_flags_vertical = 3
-theme_override_constants/margin_right = 70
-theme_override_constants/margin_top = 40
-theme_override_constants/margin_left = 70
-theme_override_constants/margin_bottom = 60
-__meta__ = {
-"_edit_use_anchors_": false
-}
+[node name="Control" type="Control" parent="."]
+layout_mode = 3
+anchors_preset = 0
 
-[node name="Panel" type="Panel" parent="MarginContainer2"]
-offset_left = 70.0
-offset_top = 40.0
-offset_right = 290.0
-offset_bottom = 120.0
-size_flags_horizontal = 3
-theme_override_styles/panel = SubResource( 1 )
+[node name="MarginContainer2" type="MarginContainer" parent="Control"]
+layout_mode = 0
+offset_right = 300.0
+offset_bottom = 100.0
+size_flags_horizontal = 4
 
-[node name="MarginContainer" type="MarginContainer" parent="MarginContainer2/Panel"]
-offset_right = 220.0
-offset_bottom = 80.0
+[node name="Panel" type="Panel" parent="Control/MarginContainer2"]
+custom_minimum_size = Vector2(300, 100)
+layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 4
+theme_override_styles/panel = SubResource("1")
+
+[node name="MarginContainer" type="MarginContainer" parent="Control/MarginContainer2/Panel"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
 size_flags_horizontal = 3
-theme_override_constants/margin_right = 0
-theme_override_constants/margin_top = 8
 theme_override_constants/margin_left = 8
+theme_override_constants/margin_top = 8
+theme_override_constants/margin_right = 0
 theme_override_constants/margin_bottom = 8
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
-[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer2/Panel/MarginContainer"]
-offset_left = 8.0
-offset_top = 8.0
-offset_right = 220.0
-offset_bottom = 72.0
-size_flags_horizontal = 3
+[node name="VBoxContainer" type="VBoxContainer" parent="Control/MarginContainer2/Panel/MarginContainer"]
+layout_mode = 2
 
-[node name="PanelContainer" type="PanelContainer" parent="MarginContainer2/Panel/MarginContainer/VBoxContainer"]
-offset_right = 220.0
-offset_bottom = 18.0
-size_flags_horizontal = 3
-theme_override_styles/panel = SubResource( 2 )
+[node name="PanelContainer" type="PanelContainer" parent="Control/MarginContainer2/Panel/MarginContainer/VBoxContainer"]
+layout_mode = 2
+size_flags_vertical = 3
+theme_override_styles/panel = SubResource("2")
 
-[node name="Message" type="Label" parent="MarginContainer2/Panel/MarginContainer/VBoxContainer/PanelContainer"]
-offset_right = 220.0
-offset_bottom = 18.0
+[node name="Message" type="Label" parent="Control/MarginContainer2/Panel/MarginContainer/VBoxContainer/PanelContainer"]
+layout_mode = 2
 size_flags_horizontal = 3
-theme_override_fonts/font = ExtResource( 2 )
+size_flags_vertical = 1
+theme_override_fonts/font = ExtResource("2")
+theme_override_font_sizes/font_size = 18
 text = "USE_NEW_CONTROLS"
-align = 1
+horizontal_alignment = 1
+vertical_alignment = 1

--- a/GameTemplate/addons/GameTemplate/GUI/BindingPopup/Popup.tscn
+++ b/GameTemplate/addons/GameTemplate/GUI/BindingPopup/Popup.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=5 format=2]
 
 [ext_resource path="res://addons/GameTemplate/GUI/BindingPopup/Popup.gd" type="Script" id=1]
-[ext_resource path="res://addons/GameTemplate/Assets/Fonts/pixellocale_8.tres" type="DynamicFont" id=2]
+[ext_resource path="res://addons/GameTemplate/Assets/Fonts/pixellocale_8.tres" type="FontFile" id=2]
 
 [sub_resource type="StyleBoxFlat" id=1]
 bg_color = Color( 0.0941176, 0.0784314, 0.145098, 1 )
@@ -22,56 +22,56 @@ __meta__ = {
 }
 
 [node name="MarginContainer2" type="MarginContainer" parent="."]
-margin_left = -20.0
-margin_right = 340.0
-margin_bottom = 180.0
+offset_left = -20.0
+offset_right = 340.0
+offset_bottom = 180.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
-custom_constants/margin_right = 70
-custom_constants/margin_top = 40
-custom_constants/margin_left = 70
-custom_constants/margin_bottom = 60
+theme_override_constants/margin_right = 70
+theme_override_constants/margin_top = 40
+theme_override_constants/margin_left = 70
+theme_override_constants/margin_bottom = 60
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
 [node name="Panel" type="Panel" parent="MarginContainer2"]
-margin_left = 70.0
-margin_top = 40.0
-margin_right = 290.0
-margin_bottom = 120.0
+offset_left = 70.0
+offset_top = 40.0
+offset_right = 290.0
+offset_bottom = 120.0
 size_flags_horizontal = 3
-custom_styles/panel = SubResource( 1 )
+theme_override_styles/panel = SubResource( 1 )
 
 [node name="MarginContainer" type="MarginContainer" parent="MarginContainer2/Panel"]
-margin_right = 220.0
-margin_bottom = 80.0
+offset_right = 220.0
+offset_bottom = 80.0
 size_flags_horizontal = 3
-custom_constants/margin_right = 0
-custom_constants/margin_top = 8
-custom_constants/margin_left = 8
-custom_constants/margin_bottom = 8
+theme_override_constants/margin_right = 0
+theme_override_constants/margin_top = 8
+theme_override_constants/margin_left = 8
+theme_override_constants/margin_bottom = 8
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
 [node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer2/Panel/MarginContainer"]
-margin_left = 8.0
-margin_top = 8.0
-margin_right = 220.0
-margin_bottom = 72.0
+offset_left = 8.0
+offset_top = 8.0
+offset_right = 220.0
+offset_bottom = 72.0
 size_flags_horizontal = 3
 
 [node name="PanelContainer" type="PanelContainer" parent="MarginContainer2/Panel/MarginContainer/VBoxContainer"]
-margin_right = 220.0
-margin_bottom = 18.0
+offset_right = 220.0
+offset_bottom = 18.0
 size_flags_horizontal = 3
-custom_styles/panel = SubResource( 2 )
+theme_override_styles/panel = SubResource( 2 )
 
 [node name="Message" type="Label" parent="MarginContainer2/Panel/MarginContainer/VBoxContainer/PanelContainer"]
-margin_right = 220.0
-margin_bottom = 18.0
+offset_right = 220.0
+offset_bottom = 18.0
 size_flags_horizontal = 3
-custom_fonts/font = ExtResource( 2 )
+theme_override_fonts/font = ExtResource( 2 )
 text = "USE_NEW_CONTROLS"
 align = 1

--- a/GameTemplate/addons/GameTemplate/GUI/Buttons/DefaultButton.tscn
+++ b/GameTemplate/addons/GameTemplate/GUI/Buttons/DefaultButton.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=6 format=3 uid="uid://dp81qs74tu3ba"]
 
-[ext_resource type="FontFile" uid="uid://cj1os0is1qn2h" path="res://addons/GameTemplate/Assets/Fonts/pixellocale-v-1-4.ttf" id="1_m4uam"]
+[ext_resource type="FontFile" uid="uid://c5gjw5i0akjja" path="res://Assets/Fonts/pixellocale-v-1-4.ttf" id="1_whnd3"]
 
 [sub_resource type="StyleBoxFlat" id="3"]
 content_margin_left = 2.0
@@ -83,9 +83,9 @@ expand_margin_bottom = 1.0
 anti_aliasing = false
 
 [node name="DefaultButton" type="Button"]
-offset_right = 42.0
-offset_bottom = 20.0
-theme_override_fonts/font = ExtResource("1_m4uam")
+offset_right = 58.0
+offset_bottom = 24.0
+theme_override_fonts/font = ExtResource("1_whnd3")
 theme_override_font_sizes/font_size = 18
 theme_override_styles/focus = SubResource("3")
 theme_override_styles/disabled = SubResource("4")

--- a/GameTemplate/addons/GameTemplate/GUI/Buttons/DefaultButton.tscn
+++ b/GameTemplate/addons/GameTemplate/GUI/Buttons/DefaultButton.tscn
@@ -1,72 +1,6 @@
-[gd_scene load_steps=7 format=3 uid="uid://dp81qs74tu3ba"]
+[gd_scene load_steps=6 format=3 uid="uid://dp81qs74tu3ba"]
 
 [ext_resource type="FontFile" uid="uid://cj1os0is1qn2h" path="res://addons/GameTemplate/Assets/Fonts/pixellocale-v-1-4.ttf" id="1_m4uam"]
-
-[sub_resource type="FontFile" id="FontFile_4wxgj"]
-fallbacks = Array[Font]([ExtResource("1_m4uam")])
-subpixel_positioning = 0
-msdf_pixel_range = 14
-msdf_size = 128
-cache/0/16/0/ascent = 0.0
-cache/0/16/0/descent = 0.0
-cache/0/16/0/underline_position = 0.0
-cache/0/16/0/underline_thickness = 0.0
-cache/0/16/0/scale = 1.0
-cache/0/50/0/ascent = 0.0
-cache/0/50/0/descent = 0.0
-cache/0/50/0/underline_position = 0.0
-cache/0/50/0/underline_thickness = 0.0
-cache/0/50/0/scale = 1.0
-cache/0/2/0/ascent = 0.0
-cache/0/2/0/descent = 0.0
-cache/0/2/0/underline_position = 0.0
-cache/0/2/0/underline_thickness = 0.0
-cache/0/2/0/scale = 1.0
-cache/0/3/0/ascent = 0.0
-cache/0/3/0/descent = 0.0
-cache/0/3/0/underline_position = 0.0
-cache/0/3/0/underline_thickness = 0.0
-cache/0/3/0/scale = 1.0
-cache/0/4/0/ascent = 0.0
-cache/0/4/0/descent = 0.0
-cache/0/4/0/underline_position = 0.0
-cache/0/4/0/underline_thickness = 0.0
-cache/0/4/0/scale = 1.0
-cache/0/5/0/ascent = 0.0
-cache/0/5/0/descent = 0.0
-cache/0/5/0/underline_position = 0.0
-cache/0/5/0/underline_thickness = 0.0
-cache/0/5/0/scale = 1.0
-cache/0/6/0/ascent = 0.0
-cache/0/6/0/descent = 0.0
-cache/0/6/0/underline_position = 0.0
-cache/0/6/0/underline_thickness = 0.0
-cache/0/6/0/scale = 1.0
-cache/0/7/0/ascent = 0.0
-cache/0/7/0/descent = 0.0
-cache/0/7/0/underline_position = 0.0
-cache/0/7/0/underline_thickness = 0.0
-cache/0/7/0/scale = 1.0
-cache/0/8/0/ascent = 0.0
-cache/0/8/0/descent = 0.0
-cache/0/8/0/underline_position = 0.0
-cache/0/8/0/underline_thickness = 0.0
-cache/0/8/0/scale = 1.0
-cache/0/9/0/ascent = 0.0
-cache/0/9/0/descent = 0.0
-cache/0/9/0/underline_position = 0.0
-cache/0/9/0/underline_thickness = 0.0
-cache/0/9/0/scale = 1.0
-cache/0/10/0/ascent = 0.0
-cache/0/10/0/descent = 0.0
-cache/0/10/0/underline_position = 0.0
-cache/0/10/0/underline_thickness = 0.0
-cache/0/10/0/scale = 1.0
-cache/0/15/0/ascent = 0.0
-cache/0/15/0/descent = 0.0
-cache/0/15/0/underline_position = 0.0
-cache/0/15/0/underline_thickness = 0.0
-cache/0/15/0/scale = 1.0
 
 [sub_resource type="StyleBoxFlat" id="3"]
 content_margin_left = 2.0
@@ -149,10 +83,10 @@ expand_margin_bottom = 1.0
 anti_aliasing = false
 
 [node name="DefaultButton" type="Button"]
-offset_right = 72.0
-offset_bottom = 35.0
-theme_override_fonts/font = SubResource("FontFile_4wxgj")
-theme_override_font_sizes/font_size = 16
+offset_right = 42.0
+offset_bottom = 20.0
+theme_override_fonts/font = ExtResource("1_m4uam")
+theme_override_font_sizes/font_size = 18
 theme_override_styles/focus = SubResource("3")
 theme_override_styles/disabled = SubResource("4")
 theme_override_styles/hover = SubResource("1")

--- a/GameTemplate/addons/GameTemplate/GUI/Buttons/DefaultButton.tscn
+++ b/GameTemplate/addons/GameTemplate/GUI/Buttons/DefaultButton.tscn
@@ -1,18 +1,84 @@
-[gd_scene load_steps=6 format=2]
+[gd_scene load_steps=7 format=3 uid="uid://dp81qs74tu3ba"]
 
-[ext_resource path="res://Assets/Fonts/pixellocale_8.tres" type="DynamicFont" id=1]
+[ext_resource type="FontFile" uid="uid://cj1os0is1qn2h" path="res://addons/GameTemplate/Assets/Fonts/pixellocale-v-1-4.ttf" id="1_m4uam"]
 
-[sub_resource type="StyleBoxFlat" id=1]
+[sub_resource type="FontFile" id="FontFile_4wxgj"]
+fallbacks = Array[Font]([ExtResource("1_m4uam")])
+subpixel_positioning = 0
+msdf_pixel_range = 14
+msdf_size = 128
+cache/0/16/0/ascent = 0.0
+cache/0/16/0/descent = 0.0
+cache/0/16/0/underline_position = 0.0
+cache/0/16/0/underline_thickness = 0.0
+cache/0/16/0/scale = 1.0
+cache/0/50/0/ascent = 0.0
+cache/0/50/0/descent = 0.0
+cache/0/50/0/underline_position = 0.0
+cache/0/50/0/underline_thickness = 0.0
+cache/0/50/0/scale = 1.0
+cache/0/2/0/ascent = 0.0
+cache/0/2/0/descent = 0.0
+cache/0/2/0/underline_position = 0.0
+cache/0/2/0/underline_thickness = 0.0
+cache/0/2/0/scale = 1.0
+cache/0/3/0/ascent = 0.0
+cache/0/3/0/descent = 0.0
+cache/0/3/0/underline_position = 0.0
+cache/0/3/0/underline_thickness = 0.0
+cache/0/3/0/scale = 1.0
+cache/0/4/0/ascent = 0.0
+cache/0/4/0/descent = 0.0
+cache/0/4/0/underline_position = 0.0
+cache/0/4/0/underline_thickness = 0.0
+cache/0/4/0/scale = 1.0
+cache/0/5/0/ascent = 0.0
+cache/0/5/0/descent = 0.0
+cache/0/5/0/underline_position = 0.0
+cache/0/5/0/underline_thickness = 0.0
+cache/0/5/0/scale = 1.0
+cache/0/6/0/ascent = 0.0
+cache/0/6/0/descent = 0.0
+cache/0/6/0/underline_position = 0.0
+cache/0/6/0/underline_thickness = 0.0
+cache/0/6/0/scale = 1.0
+cache/0/7/0/ascent = 0.0
+cache/0/7/0/descent = 0.0
+cache/0/7/0/underline_position = 0.0
+cache/0/7/0/underline_thickness = 0.0
+cache/0/7/0/scale = 1.0
+cache/0/8/0/ascent = 0.0
+cache/0/8/0/descent = 0.0
+cache/0/8/0/underline_position = 0.0
+cache/0/8/0/underline_thickness = 0.0
+cache/0/8/0/scale = 1.0
+cache/0/9/0/ascent = 0.0
+cache/0/9/0/descent = 0.0
+cache/0/9/0/underline_position = 0.0
+cache/0/9/0/underline_thickness = 0.0
+cache/0/9/0/scale = 1.0
+cache/0/10/0/ascent = 0.0
+cache/0/10/0/descent = 0.0
+cache/0/10/0/underline_position = 0.0
+cache/0/10/0/underline_thickness = 0.0
+cache/0/10/0/scale = 1.0
+cache/0/15/0/ascent = 0.0
+cache/0/15/0/descent = 0.0
+cache/0/15/0/underline_position = 0.0
+cache/0/15/0/underline_thickness = 0.0
+cache/0/15/0/scale = 1.0
+
+[sub_resource type="StyleBoxFlat" id="3"]
 content_margin_left = 2.0
-content_margin_right = 2.0
 content_margin_top = 0.0
+content_margin_right = 2.0
 content_margin_bottom = 1.0
-bg_color = Color( 0.0705882, 0.305882, 0.537255, 1 )
+bg_color = Color(0.14902, 0.168627, 0.266667, 0)
 border_width_left = 1
 border_width_top = 1
 border_width_right = 1
 border_width_bottom = 1
-border_color = Color( 1, 1, 1, 0 )
+border_color = Color(0.0705882, 0.305882, 0.537255, 1)
 corner_radius_top_left = 2
 corner_radius_top_right = 2
 corner_radius_bottom_right = 2
@@ -23,17 +89,34 @@ expand_margin_right = 2.0
 expand_margin_bottom = 1.0
 anti_aliasing = false
 
-[sub_resource type="StyleBoxFlat" id=2]
+[sub_resource type="StyleBoxFlat" id="4"]
 content_margin_left = 2.0
-content_margin_right = 2.0
 content_margin_top = 0.0
+content_margin_right = 2.0
 content_margin_bottom = 1.0
-bg_color = Color( 0.227451, 0.266667, 0.4, 1 )
+bg_color = Color(0.14902, 0.168627, 0.266667, 1)
 border_width_left = 1
 border_width_top = 1
 border_width_right = 1
 border_width_bottom = 1
-border_color = Color( 1, 1, 1, 0 )
+border_color = Color(1, 1, 1, 0)
+corner_detail = 1
+expand_margin_left = 2.0
+expand_margin_right = 2.0
+expand_margin_bottom = 1.0
+anti_aliasing = false
+
+[sub_resource type="StyleBoxFlat" id="1"]
+content_margin_left = 2.0
+content_margin_top = 0.0
+content_margin_right = 2.0
+content_margin_bottom = 1.0
+bg_color = Color(0.0705882, 0.305882, 0.537255, 1)
+border_width_left = 1
+border_width_top = 1
+border_width_right = 1
+border_width_bottom = 1
+border_color = Color(1, 1, 1, 0)
 corner_radius_top_left = 2
 corner_radius_top_right = 2
 corner_radius_bottom_right = 2
@@ -44,38 +127,21 @@ expand_margin_right = 2.0
 expand_margin_bottom = 1.0
 anti_aliasing = false
 
-[sub_resource type="StyleBoxFlat" id=3]
+[sub_resource type="StyleBoxFlat" id="2"]
 content_margin_left = 2.0
-content_margin_right = 2.0
 content_margin_top = 0.0
+content_margin_right = 2.0
 content_margin_bottom = 1.0
-bg_color = Color( 0.14902, 0.168627, 0.266667, 0 )
+bg_color = Color(0.227451, 0.266667, 0.4, 1)
 border_width_left = 1
 border_width_top = 1
 border_width_right = 1
 border_width_bottom = 1
-border_color = Color( 0.0705882, 0.305882, 0.537255, 1 )
+border_color = Color(1, 1, 1, 0)
 corner_radius_top_left = 2
 corner_radius_top_right = 2
 corner_radius_bottom_right = 2
 corner_radius_bottom_left = 2
-corner_detail = 1
-expand_margin_left = 2.0
-expand_margin_right = 2.0
-expand_margin_bottom = 1.0
-anti_aliasing = false
-
-[sub_resource type="StyleBoxFlat" id=4]
-content_margin_left = 2.0
-content_margin_right = 2.0
-content_margin_top = 0.0
-content_margin_bottom = 1.0
-bg_color = Color( 0.14902, 0.168627, 0.266667, 1 )
-border_width_left = 1
-border_width_top = 1
-border_width_right = 1
-border_width_bottom = 1
-border_color = Color( 1, 1, 1, 0 )
 corner_detail = 1
 expand_margin_left = 2.0
 expand_margin_right = 2.0
@@ -83,17 +149,13 @@ expand_margin_bottom = 1.0
 anti_aliasing = false
 
 [node name="DefaultButton" type="Button"]
-margin_right = 41.0
-margin_bottom = 19.0
-size_flags_horizontal = 3
-size_flags_vertical = 4
-custom_styles/hover = SubResource( 1 )
-custom_styles/pressed = SubResource( 2 )
-custom_styles/focus = SubResource( 3 )
-custom_styles/disabled = SubResource( 4 )
-custom_styles/normal = SubResource( 4 )
-custom_fonts/font = ExtResource( 1 )
+offset_right = 72.0
+offset_bottom = 35.0
+theme_override_fonts/font = SubResource("FontFile_4wxgj")
+theme_override_font_sizes/font_size = 16
+theme_override_styles/focus = SubResource("3")
+theme_override_styles/disabled = SubResource("4")
+theme_override_styles/hover = SubResource("1")
+theme_override_styles/pressed = SubResource("2")
+theme_override_styles/normal = SubResource("4")
 text = "Button"
-__meta__ = {
-"_edit_use_anchors_": false
-}

--- a/GameTemplate/addons/GameTemplate/GUI/Buttons/OptionsSlider.tscn
+++ b/GameTemplate/addons/GameTemplate/GUI/Buttons/OptionsSlider.tscn
@@ -1,58 +1,47 @@
-[gd_scene load_steps=8 format=2]
+[gd_scene load_steps=8 format=3 uid="uid://bfab4a8yhcgje"]
 
-[ext_resource path="res://addons/GameTemplate/Assets/Fonts/pixellocale_8.tres" type="DynamicFont" id=1]
-[ext_resource path="res://addons/GameTemplate/Assets/Images/SliderGrabber1.png" type="Texture" id=2]
-[ext_resource path="res://addons/GameTemplate/Assets/Images/SliderGrabber2.png" type="Texture" id=3]
-[ext_resource path="res://addons/GameTemplate/Assets/Images/Slider1.png" type="Texture" id=4]
-[ext_resource path="res://addons/GameTemplate/Assets/Images/Slider2.png" type="Texture" id=5]
+[ext_resource type="FontFile" path="res://addons/GameTemplate/Assets/Fonts/pixellocale_8.tres" id="1"]
+[ext_resource type="Texture2D" uid="uid://c3texvstwa4yx" path="res://addons/GameTemplate/Assets/Images/SliderGrabber1.png" id="2"]
+[ext_resource type="Texture2D" uid="uid://unw2786rna32" path="res://addons/GameTemplate/Assets/Images/SliderGrabber2.png" id="3"]
+[ext_resource type="Texture2D" uid="uid://cmov50y4ytc16" path="res://addons/GameTemplate/Assets/Images/Slider1.png" id="4"]
+[ext_resource type="Texture2D" uid="uid://cvq85e6qqmqsr" path="res://addons/GameTemplate/Assets/Images/Slider2.png" id="5"]
 
-[sub_resource type="StyleBoxTexture" id=1]
-texture = ExtResource( 4 )
-region_rect = Rect2( 0, 0, 7, 6 )
-margin_left = 3.0
-margin_right = 3.0
-margin_top = 2.0
-margin_bottom = 2.0
-axis_stretch_horizontal = 2
-axis_stretch_vertical = 2
+[sub_resource type="StyleBoxTexture" id="StyleBoxTexture_qqa8f"]
+texture = ExtResource("4")
+texture_margin_left = 3.0
+texture_margin_top = 3.0
+texture_margin_right = 3.0
+texture_margin_bottom = 3.0
 
-[sub_resource type="StyleBoxTexture" id=2]
-texture = ExtResource( 5 )
-region_rect = Rect2( 0, 0, 7, 6 )
-margin_left = 3.0
-margin_right = 3.0
-margin_top = 2.0
-margin_bottom = 2.0
-axis_stretch_horizontal = 2
-axis_stretch_vertical = 2
+[sub_resource type="StyleBoxTexture" id="StyleBoxTexture_dlwws"]
+texture = ExtResource("5")
+texture_margin_left = 3.0
+texture_margin_top = 3.0
+texture_margin_right = 3.0
+texture_margin_bottom = 3.0
 
 [node name="Master" type="VBoxContainer"]
-margin_right = 47.0
-margin_bottom = 32.0
-__meta__ = {
-"_edit_use_anchors_": false
-}
+offset_right = 47.0
+offset_bottom = 32.0
 
 [node name="ScaleName" type="Label" parent="."]
-margin_right = 47.0
-margin_bottom = 18.0
-rect_min_size = Vector2( 36, 0 )
+custom_minimum_size = Vector2(36, 0)
+layout_mode = 2
 size_flags_vertical = 1
-custom_fonts/font = ExtResource( 1 )
+theme_override_fonts/font = ExtResource("1")
 text = "Master"
-align = 1
+horizontal_alignment = 1
 
 [node name="HSlider" type="HSlider" parent="."]
-margin_top = 22.0
-margin_right = 47.0
-margin_bottom = 32.0
+layout_mode = 2
 size_flags_horizontal = 3
-custom_icons/tick = ExtResource( 2 )
-custom_icons/grabber_disabled = ExtResource( 2 )
-custom_icons/grabber_highlight = ExtResource( 3 )
-custom_icons/grabber = ExtResource( 2 )
-custom_styles/slider = SubResource( 1 )
-custom_styles/grabber_area = SubResource( 2 )
+theme_override_icons/grabber = ExtResource("2")
+theme_override_icons/grabber_highlight = ExtResource("3")
+theme_override_icons/grabber_disabled = ExtResource("2")
+theme_override_icons/tick = ExtResource("2")
+theme_override_styles/slider = SubResource("StyleBoxTexture_qqa8f")
+theme_override_styles/grabber_area = SubResource("StyleBoxTexture_dlwws")
+theme_override_styles/grabber_area_highlight = SubResource("StyleBoxTexture_dlwws")
 step = 10.0
 value = 50.0
 ticks_on_borders = true

--- a/GameTemplate/addons/GameTemplate/GUI/Buttons/TextureButton.tscn
+++ b/GameTemplate/addons/GameTemplate/GUI/Buttons/TextureButton.tscn
@@ -65,9 +65,14 @@ cache/0/12/0/descent = 0.0
 cache/0/12/0/underline_position = 0.0
 cache/0/12/0/underline_thickness = 0.0
 cache/0/12/0/scale = 1.0
+cache/0/18/0/ascent = 0.0
+cache/0/18/0/descent = 0.0
+cache/0/18/0/underline_position = 0.0
+cache/0/18/0/underline_thickness = 0.0
+cache/0/18/0/scale = 1.0
 
 [sub_resource type="LabelSettings" id="LabelSettings_38x3o"]
-font_size = 8
+font_size = 18
 
 [node name="ScaleUp" type="TextureButton"]
 size_flags_vertical = 4
@@ -77,9 +82,15 @@ texture_focused = ExtResource("3")
 
 [node name="Label" type="Label" parent="."]
 layout_mode = 1
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -5.0
+offset_top = -21.0
+offset_right = 7.0
+offset_bottom = 17.0
 grow_horizontal = 2
 grow_vertical = 2
 theme_override_fonts/font = SubResource("FontFile_6p666")

--- a/GameTemplate/addons/GameTemplate/GUI/Buttons/TextureButton.tscn
+++ b/GameTemplate/addons/GameTemplate/GUI/Buttons/TextureButton.tscn
@@ -1,77 +1,12 @@
-[gd_scene load_steps=7 format=3 uid="uid://cirbjhf3pq0am"]
+[gd_scene load_steps=6 format=3 uid="uid://cirbjhf3pq0am"]
 
 [ext_resource type="Texture2D" uid="uid://c415qexcj6ro3" path="res://addons/GameTemplate/Assets/Images/Button1.png" id="1"]
 [ext_resource type="Texture2D" uid="uid://dwprkjlb40yti" path="res://addons/GameTemplate/Assets/Images/Button2.png" id="2"]
 [ext_resource type="Texture2D" uid="uid://u210kf7lg47v" path="res://addons/GameTemplate/Assets/Images/Button3.png" id="3"]
-[ext_resource type="FontFile" uid="uid://cj1os0is1qn2h" path="res://addons/GameTemplate/Assets/Fonts/pixellocale-v-1-4.ttf" id="4_wp8qa"]
-
-[sub_resource type="FontFile" id="FontFile_6p666"]
-fallbacks = Array[Font]([ExtResource("4_wp8qa")])
-subpixel_positioning = 0
-msdf_pixel_range = 14
-msdf_size = 128
-cache/0/16/0/ascent = 0.0
-cache/0/16/0/descent = 0.0
-cache/0/16/0/underline_position = 0.0
-cache/0/16/0/underline_thickness = 0.0
-cache/0/16/0/scale = 1.0
-cache/0/50/0/ascent = 0.0
-cache/0/50/0/descent = 0.0
-cache/0/50/0/underline_position = 0.0
-cache/0/50/0/underline_thickness = 0.0
-cache/0/50/0/scale = 1.0
-cache/0/7/0/ascent = 0.0
-cache/0/7/0/descent = 0.0
-cache/0/7/0/underline_position = 0.0
-cache/0/7/0/underline_thickness = 0.0
-cache/0/7/0/scale = 1.0
-cache/0/8/0/ascent = 0.0
-cache/0/8/0/descent = 0.0
-cache/0/8/0/underline_position = 0.0
-cache/0/8/0/underline_thickness = 0.0
-cache/0/8/0/scale = 1.0
-cache/0/9/0/ascent = 0.0
-cache/0/9/0/descent = 0.0
-cache/0/9/0/underline_position = 0.0
-cache/0/9/0/underline_thickness = 0.0
-cache/0/9/0/scale = 1.0
-cache/0/10/0/ascent = 0.0
-cache/0/10/0/descent = 0.0
-cache/0/10/0/underline_position = 0.0
-cache/0/10/0/underline_thickness = 0.0
-cache/0/10/0/scale = 1.0
-cache/0/11/0/ascent = 0.0
-cache/0/11/0/descent = 0.0
-cache/0/11/0/underline_position = 0.0
-cache/0/11/0/underline_thickness = 0.0
-cache/0/11/0/scale = 1.0
-cache/0/15/0/ascent = 0.0
-cache/0/15/0/descent = 0.0
-cache/0/15/0/underline_position = 0.0
-cache/0/15/0/underline_thickness = 0.0
-cache/0/15/0/scale = 1.0
-cache/0/14/0/ascent = 0.0
-cache/0/14/0/descent = 0.0
-cache/0/14/0/underline_position = 0.0
-cache/0/14/0/underline_thickness = 0.0
-cache/0/14/0/scale = 1.0
-cache/0/13/0/ascent = 0.0
-cache/0/13/0/descent = 0.0
-cache/0/13/0/underline_position = 0.0
-cache/0/13/0/underline_thickness = 0.0
-cache/0/13/0/scale = 1.0
-cache/0/12/0/ascent = 0.0
-cache/0/12/0/descent = 0.0
-cache/0/12/0/underline_position = 0.0
-cache/0/12/0/underline_thickness = 0.0
-cache/0/12/0/scale = 1.0
-cache/0/18/0/ascent = 0.0
-cache/0/18/0/descent = 0.0
-cache/0/18/0/underline_position = 0.0
-cache/0/18/0/underline_thickness = 0.0
-cache/0/18/0/scale = 1.0
+[ext_resource type="FontFile" uid="uid://c5gjw5i0akjja" path="res://Assets/Fonts/pixellocale-v-1-4.ttf" id="4_lssuk"]
 
 [sub_resource type="LabelSettings" id="LabelSettings_38x3o"]
+font = ExtResource("4_lssuk")
 font_size = 18
 
 [node name="ScaleUp" type="TextureButton"]
@@ -93,7 +28,6 @@ offset_right = 7.0
 offset_bottom = 17.0
 grow_horizontal = 2
 grow_vertical = 2
-theme_override_fonts/font = SubResource("FontFile_6p666")
 text = "+"
 label_settings = SubResource("LabelSettings_38x3o")
 horizontal_alignment = 1

--- a/GameTemplate/addons/GameTemplate/GUI/Buttons/TextureButton.tscn
+++ b/GameTemplate/addons/GameTemplate/GUI/Buttons/TextureButton.tscn
@@ -1,30 +1,89 @@
-[gd_scene load_steps=5 format=2]
+[gd_scene load_steps=7 format=3 uid="uid://cirbjhf3pq0am"]
 
-[ext_resource path="res://addons/GameTemplate/Assets/Images/Button1.png" type="Texture" id=1]
-[ext_resource path="res://addons/GameTemplate/Assets/Images/Button2.png" type="Texture" id=2]
-[ext_resource path="res://addons/GameTemplate/Assets/Images/Button3.png" type="Texture" id=3]
-[ext_resource path="res://addons/GameTemplate/Assets/Fonts/pixellocale_8.tres" type="DynamicFont" id=4]
+[ext_resource type="Texture2D" uid="uid://c415qexcj6ro3" path="res://addons/GameTemplate/Assets/Images/Button1.png" id="1"]
+[ext_resource type="Texture2D" uid="uid://dwprkjlb40yti" path="res://addons/GameTemplate/Assets/Images/Button2.png" id="2"]
+[ext_resource type="Texture2D" uid="uid://u210kf7lg47v" path="res://addons/GameTemplate/Assets/Images/Button3.png" id="3"]
+[ext_resource type="FontFile" uid="uid://cj1os0is1qn2h" path="res://addons/GameTemplate/Assets/Fonts/pixellocale-v-1-4.ttf" id="4_wp8qa"]
+
+[sub_resource type="FontFile" id="FontFile_6p666"]
+fallbacks = Array[Font]([ExtResource("4_wp8qa")])
+subpixel_positioning = 0
+msdf_pixel_range = 14
+msdf_size = 128
+cache/0/16/0/ascent = 0.0
+cache/0/16/0/descent = 0.0
+cache/0/16/0/underline_position = 0.0
+cache/0/16/0/underline_thickness = 0.0
+cache/0/16/0/scale = 1.0
+cache/0/50/0/ascent = 0.0
+cache/0/50/0/descent = 0.0
+cache/0/50/0/underline_position = 0.0
+cache/0/50/0/underline_thickness = 0.0
+cache/0/50/0/scale = 1.0
+cache/0/7/0/ascent = 0.0
+cache/0/7/0/descent = 0.0
+cache/0/7/0/underline_position = 0.0
+cache/0/7/0/underline_thickness = 0.0
+cache/0/7/0/scale = 1.0
+cache/0/8/0/ascent = 0.0
+cache/0/8/0/descent = 0.0
+cache/0/8/0/underline_position = 0.0
+cache/0/8/0/underline_thickness = 0.0
+cache/0/8/0/scale = 1.0
+cache/0/9/0/ascent = 0.0
+cache/0/9/0/descent = 0.0
+cache/0/9/0/underline_position = 0.0
+cache/0/9/0/underline_thickness = 0.0
+cache/0/9/0/scale = 1.0
+cache/0/10/0/ascent = 0.0
+cache/0/10/0/descent = 0.0
+cache/0/10/0/underline_position = 0.0
+cache/0/10/0/underline_thickness = 0.0
+cache/0/10/0/scale = 1.0
+cache/0/11/0/ascent = 0.0
+cache/0/11/0/descent = 0.0
+cache/0/11/0/underline_position = 0.0
+cache/0/11/0/underline_thickness = 0.0
+cache/0/11/0/scale = 1.0
+cache/0/15/0/ascent = 0.0
+cache/0/15/0/descent = 0.0
+cache/0/15/0/underline_position = 0.0
+cache/0/15/0/underline_thickness = 0.0
+cache/0/15/0/scale = 1.0
+cache/0/14/0/ascent = 0.0
+cache/0/14/0/descent = 0.0
+cache/0/14/0/underline_position = 0.0
+cache/0/14/0/underline_thickness = 0.0
+cache/0/14/0/scale = 1.0
+cache/0/13/0/ascent = 0.0
+cache/0/13/0/descent = 0.0
+cache/0/13/0/underline_position = 0.0
+cache/0/13/0/underline_thickness = 0.0
+cache/0/13/0/scale = 1.0
+cache/0/12/0/ascent = 0.0
+cache/0/12/0/descent = 0.0
+cache/0/12/0/underline_position = 0.0
+cache/0/12/0/underline_thickness = 0.0
+cache/0/12/0/scale = 1.0
+
+[sub_resource type="LabelSettings" id="LabelSettings_38x3o"]
+font_size = 8
 
 [node name="ScaleUp" type="TextureButton"]
 size_flags_vertical = 4
-texture_normal = ExtResource( 1 )
-texture_pressed = ExtResource( 2 )
-texture_focused = ExtResource( 3 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
+texture_normal = ExtResource("1")
+texture_pressed = ExtResource("2")
+texture_focused = ExtResource("3")
 
 [node name="Label" type="Label" parent="."]
-anchor_left = 0.5
-anchor_top = 0.5
-anchor_right = 0.5
-anchor_bottom = 0.5
-margin_left = -3.0
-margin_top = -8.0
-margin_right = 2.0
-margin_bottom = 10.0
-custom_fonts/font = ExtResource( 4 )
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_fonts/font = SubResource("FontFile_6p666")
 text = "+"
-__meta__ = {
-"_edit_use_anchors_": false
-}
+label_settings = SubResource("LabelSettings_38x3o")
+horizontal_alignment = 1
+vertical_alignment = 1

--- a/GameTemplate/addons/GameTemplate/GUI/Buttons/ToggleButton.tscn
+++ b/GameTemplate/addons/GameTemplate/GUI/Buttons/ToggleButton.tscn
@@ -1,52 +1,11 @@
-[gd_scene load_steps=10 format=2]
+[gd_scene load_steps=3 format=3 uid="uid://jepfs4ovtw3x"]
 
-[ext_resource path="res://addons/GameTemplate/Assets/Images/Toggle2.png" type="Texture" id=1]
-[ext_resource path="res://addons/GameTemplate/Assets/Images/Toggle1.png" type="Texture" id=2]
-[ext_resource path="res://addons/GameTemplate/Assets/Fonts/pixellocale_16.tres" type="DynamicFont" id=3]
-
-
-[sub_resource type="StyleBoxEmpty" id=1]
-
-[sub_resource type="StyleBoxEmpty" id=2]
-
-[sub_resource type="StyleBoxFlat" id=3]
-content_margin_left = 2.0
-content_margin_right = 2.0
-content_margin_top = 2.0
-content_margin_bottom = 2.0
-bg_color = Color( 0.6, 0.6, 0.6, 0 )
-border_width_left = 1
-border_width_top = 1
-border_width_right = 1
-border_width_bottom = 1
-border_color = Color( 0.0705882, 0.305882, 0.537255, 1 )
-corner_radius_top_left = 2
-corner_radius_top_right = 2
-corner_radius_bottom_right = 2
-corner_radius_bottom_left = 2
-corner_detail = 1
-anti_aliasing = false
-
-[sub_resource type="StyleBoxEmpty" id=4]
-
-[sub_resource type="StyleBoxEmpty" id=5]
-
-[sub_resource type="StyleBoxEmpty" id=6]
+[ext_resource type="FontFile" path="res://addons/GameTemplate/Assets/Fonts/pixellocale_8_noborder.tres" id="1_3h6on"]
+[ext_resource type="Theme" uid="uid://bjy6d6iusj4lk" path="res://addons/GameTemplate/GUI/default_theme.tres" id="1_r5cmf"]
 
 [node name="OptionsToggle" type="CheckButton"]
-margin_right = 94.0
-margin_bottom = 24.0
-size_flags_horizontal = 3
-custom_icons/off = ExtResource( 2 )
-custom_icons/on = ExtResource( 1 )
-custom_styles/hover = SubResource( 1 )
-custom_styles/pressed = SubResource( 2 )
-custom_styles/focus = SubResource( 3 )
-custom_styles/disabled = SubResource( 4 )
-custom_styles/hover_pressed = SubResource( 5 )
-custom_styles/normal = SubResource( 6 )
-custom_fonts/font = ExtResource( 3 )
+offset_right = 157.0
+offset_bottom = 42.0
+theme = ExtResource("1_r5cmf")
+theme_override_fonts/font = ExtResource("1_3h6on")
 text = "Fullscreen  "
-__meta__ = {
-"_edit_use_anchors_": false
-}

--- a/GameTemplate/addons/GameTemplate/GUI/Buttons/ToggleButton.tscn
+++ b/GameTemplate/addons/GameTemplate/GUI/Buttons/ToggleButton.tscn
@@ -1,12 +1,12 @@
 [gd_scene load_steps=3 format=3 uid="uid://jepfs4ovtw3x"]
 
 [ext_resource type="Theme" uid="uid://bjy6d6iusj4lk" path="res://addons/GameTemplate/GUI/default_theme.tres" id="1_r5cmf"]
-[ext_resource type="FontFile" uid="uid://cj1os0is1qn2h" path="res://addons/GameTemplate/Assets/Fonts/pixellocale-v-1-4.ttf" id="1_yjqxe"]
+[ext_resource type="FontFile" uid="uid://c5gjw5i0akjja" path="res://Assets/Fonts/pixellocale-v-1-4.ttf" id="2_kxaha"]
 
 [node name="OptionsToggle" type="CheckButton"]
 offset_right = 157.0
 offset_bottom = 42.0
 theme = ExtResource("1_r5cmf")
-theme_override_fonts/font = ExtResource("1_yjqxe")
+theme_override_fonts/font = ExtResource("2_kxaha")
 theme_override_font_sizes/font_size = 18
 text = "Fullscreen  "

--- a/GameTemplate/addons/GameTemplate/GUI/Buttons/ToggleButton.tscn
+++ b/GameTemplate/addons/GameTemplate/GUI/Buttons/ToggleButton.tscn
@@ -1,11 +1,12 @@
 [gd_scene load_steps=3 format=3 uid="uid://jepfs4ovtw3x"]
 
-[ext_resource type="FontFile" path="res://addons/GameTemplate/Assets/Fonts/pixellocale_8_noborder.tres" id="1_3h6on"]
 [ext_resource type="Theme" uid="uid://bjy6d6iusj4lk" path="res://addons/GameTemplate/GUI/default_theme.tres" id="1_r5cmf"]
+[ext_resource type="FontFile" uid="uid://cj1os0is1qn2h" path="res://addons/GameTemplate/Assets/Fonts/pixellocale-v-1-4.ttf" id="1_yjqxe"]
 
 [node name="OptionsToggle" type="CheckButton"]
 offset_right = 157.0
 offset_bottom = 42.0
 theme = ExtResource("1_r5cmf")
-theme_override_fonts/font = ExtResource("1_3h6on")
+theme_override_fonts/font = ExtResource("1_yjqxe")
+theme_override_font_sizes/font_size = 18
 text = "Fullscreen  "

--- a/GameTemplate/addons/GameTemplate/GUI/OptionsSections/Controls.tscn
+++ b/GameTemplate/addons/GameTemplate/GUI/OptionsSections/Controls.tscn
@@ -1,139 +1,99 @@
-[gd_scene load_steps=7 format=2]
+[gd_scene load_steps=7 format=3 uid="uid://dovclayfphu6p"]
 
-[ext_resource path="res://addons/GameTemplate/GUI/OptionsSections/Controls.gd" type="Script" id=1]
-[ext_resource path="res://addons/GameTemplate/Assets/Fonts/pixellocale_8.tres" type="DynamicFont" id=2]
-[ext_resource path="res://addons/GameTemplate/GUI/default_theme.tres" type="Theme" id=3]
-[ext_resource path="res://addons/GameTemplate/GUI/BindingPopup/Popup.tscn" type="PackedScene" id=4]
-[ext_resource path="res://addons/GameTemplate/GUI/Buttons/DefaultButton.tscn" type="PackedScene" id=5]
+[ext_resource type="Script" path="res://addons/GameTemplate/GUI/OptionsSections/Controls.gd" id="1"]
+[ext_resource type="FontFile" path="res://addons/GameTemplate/Assets/Fonts/pixellocale_8.tres" id="2"]
+[ext_resource type="Theme" uid="uid://bjy6d6iusj4lk" path="res://addons/GameTemplate/GUI/default_theme.tres" id="3"]
+[ext_resource type="PackedScene" path="res://addons/GameTemplate/GUI/BindingPopup/Popup.tscn" id="4"]
+[ext_resource type="PackedScene" uid="uid://dp81qs74tu3ba" path="res://addons/GameTemplate/GUI/Buttons/DefaultButton.tscn" id="5"]
 
-[sub_resource type="StyleBoxFlat" id=1]
-bg_color = Color( 0.0235294, 0.0196078, 0.0352941, 1 )
+[sub_resource type="StyleBoxFlat" id="1"]
+bg_color = Color(0.0235294, 0.0196078, 0.0352941, 1)
 corner_detail = 1
 
 [node name="Controls" type="VBoxContainer"]
+anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
-theme = ExtResource( 3 )
-custom_constants/separation = 1
-script = ExtResource( 1 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
+theme = ExtResource("3")
+theme_override_constants/separation = 1
+script = ExtResource("1")
 
 [node name="Section" type="Control" parent="."]
-margin_right = 320.0
-margin_bottom = 160.0
+layout_mode = 2
 size_flags_vertical = 3
 
 [node name="MarginContainer" type="MarginContainer" parent="Section"]
+layout_mode = 0
 anchor_right = 1.0
 anchor_bottom = 1.0
-margin_bottom = 2.0
+offset_bottom = 2.0
 size_flags_vertical = 3
-custom_constants/margin_right = 5
-custom_constants/margin_top = 5
-custom_constants/margin_left = 5
-custom_constants/margin_bottom = 3
-__meta__ = {
-"_edit_use_anchors_": false
-}
+theme_override_constants/margin_left = 5
+theme_override_constants/margin_top = 5
+theme_override_constants/margin_right = 5
+theme_override_constants/margin_bottom = 3
 
 [node name="ScrollContainer" type="ScrollContainer" parent="Section/MarginContainer"]
-margin_left = 5.0
-margin_top = 5.0
-margin_right = 315.0
-margin_bottom = 159.0
+layout_mode = 2
 size_flags_horizontal = 3
 
 [node name="ActionsSection" type="VBoxContainer" parent="Section/MarginContainer/ScrollContainer"]
-margin_right = 310.0
-margin_bottom = 154.0
+layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
-custom_constants/separation = 0
+theme_override_constants/separation = 0
 
 [node name="PanelContainer" type="PanelContainer" parent="Section/MarginContainer/ScrollContainer/ActionsSection"]
-margin_right = 310.0
-margin_bottom = 18.0
-custom_styles/panel = SubResource( 1 )
+layout_mode = 2
+theme_override_styles/panel = SubResource("1")
 
 [node name="Actions" type="Label" parent="Section/MarginContainer/ScrollContainer/ActionsSection/PanelContainer"]
-margin_left = 134.0
-margin_right = 175.0
-margin_bottom = 18.0
+layout_mode = 2
 size_flags_horizontal = 4
-custom_fonts/font = ExtResource( 2 )
+theme_override_fonts/font = ExtResource("2")
 text = "Actions"
 
 [node name="ScrollContainer" type="ScrollContainer" parent="Section/MarginContainer/ScrollContainer/ActionsSection"]
-margin_top = 18.0
-margin_right = 310.0
-margin_bottom = 154.0
+layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 follow_focus = true
-scroll_horizontal_enabled = false
 
 [node name="ActionList" type="VBoxContainer" parent="Section/MarginContainer/ScrollContainer/ActionsSection/ScrollContainer"]
-margin_right = 310.0
-margin_bottom = 136.0
+layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
-custom_constants/separation = 0
+theme_override_constants/separation = 0
 
-[node name="Popup" parent="Section" groups=[
-"KeyBinding",
-] instance=ExtResource( 4 )]
-visible = false
+[node name="Popup" parent="Section" groups=["KeyBinding"] instance=ExtResource("4")]
 
 [node name="MarginContainer" type="MarginContainer" parent="."]
-margin_top = 161.0
-margin_right = 320.0
-margin_bottom = 180.0
+layout_mode = 2
 
 [node name="VBoxContainer" type="HBoxContainer" parent="MarginContainer"]
-margin_right = 320.0
-margin_bottom = 19.0
+layout_mode = 2
 size_flags_horizontal = 3
-custom_constants/separation = 1
+theme_override_constants/separation = 1
 
 [node name="Control" type="Control" parent="MarginContainer/VBoxContainer"]
-margin_right = 63.0
-margin_bottom = 19.0
+layout_mode = 2
 size_flags_horizontal = 3
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
-[node name="Back" parent="MarginContainer/VBoxContainer" groups=[
-"Controls",
-] instance=ExtResource( 5 )]
-margin_left = 64.0
-margin_right = 127.0
+[node name="Back" parent="MarginContainer/VBoxContainer" groups=["Controls"] instance=ExtResource("5")]
+layout_mode = 2
 text = "Back"
 
 [node name="Control2" type="Control" parent="MarginContainer/VBoxContainer"]
-margin_left = 128.0
-margin_right = 191.0
-margin_bottom = 19.0
+layout_mode = 2
 size_flags_horizontal = 3
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
-[node name="Default" parent="MarginContainer/VBoxContainer" instance=ExtResource( 5 )]
-margin_left = 192.0
-margin_right = 255.0
+[node name="Default" parent="MarginContainer/VBoxContainer" instance=ExtResource("5")]
+layout_mode = 2
 text = "Default"
 
 [node name="Control3" type="Control" parent="MarginContainer/VBoxContainer"]
-margin_left = 256.0
-margin_right = 320.0
-margin_bottom = 19.0
+layout_mode = 2
 size_flags_horizontal = 3
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [connection signal="pressed" from="MarginContainer/VBoxContainer/Back" to="." method="_on_Back_pressed"]
 [connection signal="pressed" from="MarginContainer/VBoxContainer/Default" to="." method="_on_Default_pressed"]

--- a/GameTemplate/addons/GameTemplate/GUI/OptionsSections/Controls.tscn
+++ b/GameTemplate/addons/GameTemplate/GUI/OptionsSections/Controls.tscn
@@ -3,7 +3,7 @@
 [ext_resource type="Script" path="res://addons/GameTemplate/GUI/OptionsSections/Controls.gd" id="1"]
 [ext_resource type="FontFile" path="res://addons/GameTemplate/Assets/Fonts/pixellocale_8.tres" id="2"]
 [ext_resource type="Theme" uid="uid://bjy6d6iusj4lk" path="res://addons/GameTemplate/GUI/default_theme.tres" id="3"]
-[ext_resource type="PackedScene" path="res://addons/GameTemplate/GUI/BindingPopup/Popup.tscn" id="4"]
+[ext_resource type="PackedScene" uid="uid://de226x33vcwm8" path="res://addons/GameTemplate/GUI/BindingPopup/Popup.tscn" id="4"]
 [ext_resource type="PackedScene" uid="uid://dp81qs74tu3ba" path="res://addons/GameTemplate/GUI/Buttons/DefaultButton.tscn" id="5"]
 
 [sub_resource type="StyleBoxFlat" id="1"]
@@ -51,6 +51,7 @@ theme_override_styles/panel = SubResource("1")
 layout_mode = 2
 size_flags_horizontal = 4
 theme_override_fonts/font = ExtResource("2")
+theme_override_font_sizes/font_size = 18
 text = "Actions"
 
 [node name="ScrollContainer" type="ScrollContainer" parent="Section/MarginContainer/ScrollContainer/ActionsSection"]

--- a/GameTemplate/addons/GameTemplate/GUI/OptionsSections/General.gd
+++ b/GameTemplate/addons/GameTemplate/GUI/OptionsSections/General.gd
@@ -1,36 +1,36 @@
 extends VBoxContainer
 
 #RESOLUTION
-onready var Resolution_panel:Panel = find_node("Panel")
-onready var Volume_panel:Panel = find_node("Panel2")
-onready var Language_panel:Panel = find_node("Panel3")
+@onready var Resolution_panel:Panel = find_child("Panel")
+@onready var Volume_panel:Panel = find_child("Panel2")
+@onready var Language_panel:Panel = find_child("Panel3")
 #AUDIO
-onready var Master_slider:HSlider = find_node("Master").get_node("HSlider")
-onready var Music_slider:HSlider = find_node("Music").get_node("HSlider")
-onready var SFX_slider:HSlider = find_node("SFX").get_node("HSlider")
-onready var Master_player:AudioStreamPlayer = find_node("Master").get_node("AudioStreamPlayer")
-onready var Music_player:AudioStreamPlayer = find_node("Music").get_node("AudioStreamPlayer")
-onready var SFX_player:AudioStreamPlayer = find_node("SFX").get_node("AudioStreamPlayer")
+@onready var Master_slider:HSlider = find_child("Master").get_node("HSlider")
+@onready var Music_slider:HSlider = find_child("Music").get_node("HSlider")
+@onready var SFX_slider:HSlider = find_child("SFX").get_node("HSlider")
+@onready var Master_player:AudioStreamPlayer = find_child("Master").get_node("AudioStreamPlayer")
+@onready var Music_player:AudioStreamPlayer = find_child("Music").get_node("AudioStreamPlayer")
+@onready var SFX_player:AudioStreamPlayer = find_child("SFX").get_node("AudioStreamPlayer")
 var beep: = preload("res://addons/GameTemplate/Assets/Sounds/TestBeep.wav")
 
 func _ready()->void:
 	#Set up toggles and sliders
 	if Settings.HTML5:
-		find_node("Borderless").visible = false
-		find_node("Scale").visible = false
+		find_child("Borderless").visible = false
+		find_child("Scale").visible = false
 	set_resolution()
 	set_volume_sliders()
 	
-	MenuEvent.connect("Controls", self, "on_show_controls")
-	MenuEvent.connect("Languages", self, "on_show_languages")
-	SettingsResolution.connect("Resized", self, "_on_Resized")
+	MenuEvent.connect("ControlsSignal", on_show_controls)
+	MenuEvent.connect("LanguagesSignal", on_show_languages)
+	SettingsResolution.connect("Resized", _on_Resized)
 	#Localization
-	SettingsLanguage.connect("ReTranslate", self, "retranslate")
+	SettingsLanguage.connect("ReTranslate", retranslate)
 	retranslate()
 
 func set_resolution()->void:
-	find_node("Fullscreen").pressed = SettingsResolution.Fullscreen
-	find_node("Borderless").pressed = SettingsResolution.Borderless
+	find_child("Fullscreen").button_pressed = SettingsResolution.Fullscreen
+	find_child("Borderless").button_pressed = SettingsResolution.Borderless
 	#Your logic for scaling
 
 func set_volume_sliders()->void: #Initialize volume sliders
@@ -44,24 +44,24 @@ func set_volume_sliders()->void: #Initialize volume sliders
 #### BUTTON SIGNALS ####
 func _on_Master_value_changed(value)->void:
 	SettingsAudio.VolumeMaster = value/100
-	var player:AudioStreamPlayer = find_node("Master").get_node("AudioStreamPlayer")
+	var player:AudioStreamPlayer = find_child("Master").get_node("AudioStreamPlayer")
 	player.play()
 
 func _on_Music_value_changed(value)->void:
 	SettingsAudio.VolumeMusic = value/100
-	var player:AudioStreamPlayer = find_node("Music").get_node("AudioStreamPlayer")
+	var player:AudioStreamPlayer = find_child("Music").get_node("AudioStreamPlayer")
 	player.play()
 
 func _on_SFX_value_changed(value)->void:
 	SettingsAudio.VolumeSFX = value/100
-	var player:AudioStreamPlayer = find_node("SFX").get_node("AudioStreamPlayer")
+	var player:AudioStreamPlayer = find_child("SFX").get_node("AudioStreamPlayer")
 	player.play()
 
 func _on_Fullscreen_pressed()->void:
-	SettingsResolution.Fullscreen = find_node("Fullscreen").pressed
+	SettingsResolution.set_fullscreen(find_child("Fullscreen").button_pressed)
 
 func _on_Borderless_pressed()->void:
-	SettingsResolution.Borderless = find_node("Borderless").pressed
+	SettingsResolution.set_borderless(find_child("Borderless").button_pressed)
 
 func _on_ScaleUp_pressed()->void:
 	SettingsResolution.Scale += 1
@@ -73,16 +73,17 @@ func _on_Resized()->void:
 	set_resolution()
 
 func _on_Controls_pressed()->void:
-	MenuEvent.Controls = true
+	MenuEvent.Controls_val = true
 
 func _on_Back_pressed()->void:
 	SettingsSaveLoad.save_settings()
-	MenuEvent.Options = false
+	MenuEvent.Options_val = false
 	if PauseMenu.can_show:
 		get_tree().get_nodes_in_group("Pause")[0].grab_focus()
 
+
 func _on_Languages_pressed()->void:
-	MenuEvent.Languages = true
+	MenuEvent.Languages_val = true
 
 #EVENT SIGNALS
 func on_show_controls(value:bool)->void:
@@ -97,17 +98,17 @@ func on_show_languages(value:bool)->void:
 
 #Localization
 func retranslate()->void:
-	find_node("Resolution").text 					= tr("RESOLUTION")
-	find_node("Volume").text 						= tr("VOLUME")
-	find_node("Fullscreen").text 					= tr("FULLSCREEN")
-	find_node("Borderless").text 					= tr("BORDERLESS")
-	find_node("Scale").text 						= tr("SCALE")
-	find_node("Master").get_node("ScaleName").text	= tr("MASTER")
-	find_node("Music").get_node("ScaleName").text 	= tr("MUSIC")
-	find_node("SFX").get_node("ScaleName").text 	= tr("SFX")
-	find_node("LanguagesButton").text 				= tr("LANGUAGES")
-	find_node("Controls").text 						= tr("CONTROLS")
-	find_node("Back").text 							= tr("BACK")
+	find_child("Resolution").text 					= tr("RESOLUTION")
+	find_child("Volume").text 						= tr("VOLUME")
+	find_child("Fullscreen").text 					= tr("FULLSCREEN")
+	find_child("Borderless").text 					= tr("BORDERLESS")
+	find_child("Scale").text 						= tr("SCALE")
+	find_child("Master").get_node("ScaleName").text	= tr("MASTER")
+	find_child("Music").get_node("ScaleName").text 	= tr("MUSIC")
+	find_child("SFX").get_node("ScaleName").text 	= tr("SFX")
+	find_child("LanguagesButton").text 				= tr("LANGUAGES")
+	find_child("Controls").text 						= tr("CONTROLS")
+	find_child("Back").text 							= tr("BACK")
 
 func set_node_in_focus()->void:
 	var FocusGroup:Array = get_groups()

--- a/GameTemplate/addons/GameTemplate/GUI/OptionsSections/General.gd
+++ b/GameTemplate/addons/GameTemplate/GUI/OptionsSections/General.gd
@@ -17,7 +17,7 @@ func _ready()->void:
 	#Set up toggles and sliders
 	if Settings.HTML5:
 		find_child("Borderless").visible = false
-		find_child("Scale").visible = false
+		find_child("ScaleGroup").visible = false
 	set_resolution()
 	set_volume_sliders()
 	

--- a/GameTemplate/addons/GameTemplate/GUI/OptionsSections/General.tscn
+++ b/GameTemplate/addons/GameTemplate/GUI/OptionsSections/General.tscn
@@ -1,261 +1,339 @@
-[gd_scene load_steps=9 format=2]
+[gd_scene load_steps=10 format=3 uid="uid://ssfa3xrbdxx5"]
 
-[ext_resource path="res://addons/GameTemplate/GUI/OptionsSections/General.gd" type="Script" id=1]
-[ext_resource path="res://addons/GameTemplate/GUI/OptionsSections/DarkerPanel.tres" type="StyleBox" id=2]
-[ext_resource path="res://addons/GameTemplate/Assets/Fonts/pixellocale_16.tres" type="DynamicFont" id=3]
-[ext_resource path="res://addons/GameTemplate/GUI/Buttons/ToggleButton.tscn" type="PackedScene" id=4]
-[ext_resource path="res://addons/GameTemplate/GUI/Buttons/TextureButton.tscn" type="PackedScene" id=5]
-[ext_resource path="res://addons/GameTemplate/GUI/Buttons/OptionsSlider.tscn" type="PackedScene" id=7]
-[ext_resource path="res://addons/GameTemplate/Assets/Fonts/pixellocale_8.tres" type="DynamicFont" id=8]
-[ext_resource path="res://addons/GameTemplate/GUI/Buttons/DefaultButton.tscn" type="PackedScene" id=9]
+[ext_resource type="Script" path="res://addons/GameTemplate/GUI/OptionsSections/General.gd" id="1"]
+[ext_resource type="StyleBox" path="res://addons/GameTemplate/GUI/OptionsSections/DarkerPanel.tres" id="2"]
+[ext_resource type="FontFile" uid="uid://cj1os0is1qn2h" path="res://addons/GameTemplate/Assets/Fonts/pixellocale-v-1-4.ttf" id="3_meltj"]
+[ext_resource type="PackedScene" uid="uid://jepfs4ovtw3x" path="res://addons/GameTemplate/GUI/Buttons/ToggleButton.tscn" id="4"]
+[ext_resource type="PackedScene" uid="uid://cirbjhf3pq0am" path="res://addons/GameTemplate/GUI/Buttons/TextureButton.tscn" id="5"]
+[ext_resource type="PackedScene" uid="uid://bfab4a8yhcgje" path="res://addons/GameTemplate/GUI/Buttons/OptionsSlider.tscn" id="7"]
+[ext_resource type="PackedScene" uid="uid://dp81qs74tu3ba" path="res://addons/GameTemplate/GUI/Buttons/DefaultButton.tscn" id="9"]
+
+[sub_resource type="FontFile" id="FontFile_4wxgj"]
+fallbacks = Array[Font]([ExtResource("3_meltj")])
+subpixel_positioning = 0
+msdf_pixel_range = 14
+msdf_size = 128
+cache/0/16/0/ascent = 0.0
+cache/0/16/0/descent = 0.0
+cache/0/16/0/underline_position = 0.0
+cache/0/16/0/underline_thickness = 0.0
+cache/0/16/0/scale = 1.0
+cache/0/50/0/ascent = 0.0
+cache/0/50/0/descent = 0.0
+cache/0/50/0/underline_position = 0.0
+cache/0/50/0/underline_thickness = 0.0
+cache/0/50/0/scale = 1.0
+cache/0/2/0/ascent = 0.0
+cache/0/2/0/descent = 0.0
+cache/0/2/0/underline_position = 0.0
+cache/0/2/0/underline_thickness = 0.0
+cache/0/2/0/scale = 1.0
+cache/0/3/0/ascent = 0.0
+cache/0/3/0/descent = 0.0
+cache/0/3/0/underline_position = 0.0
+cache/0/3/0/underline_thickness = 0.0
+cache/0/3/0/scale = 1.0
+cache/0/4/0/ascent = 0.0
+cache/0/4/0/descent = 0.0
+cache/0/4/0/underline_position = 0.0
+cache/0/4/0/underline_thickness = 0.0
+cache/0/4/0/scale = 1.0
+cache/0/5/0/ascent = 0.0
+cache/0/5/0/descent = 0.0
+cache/0/5/0/underline_position = 0.0
+cache/0/5/0/underline_thickness = 0.0
+cache/0/5/0/scale = 1.0
+cache/0/6/0/ascent = 0.0
+cache/0/6/0/descent = 0.0
+cache/0/6/0/underline_position = 0.0
+cache/0/6/0/underline_thickness = 0.0
+cache/0/6/0/scale = 1.0
+cache/0/7/0/ascent = 0.0
+cache/0/7/0/descent = 0.0
+cache/0/7/0/underline_position = 0.0
+cache/0/7/0/underline_thickness = 0.0
+cache/0/7/0/scale = 1.0
+cache/0/8/0/ascent = 0.0
+cache/0/8/0/descent = 0.0
+cache/0/8/0/underline_position = 0.0
+cache/0/8/0/underline_thickness = 0.0
+cache/0/8/0/scale = 1.0
+cache/0/9/0/ascent = 0.0
+cache/0/9/0/descent = 0.0
+cache/0/9/0/underline_position = 0.0
+cache/0/9/0/underline_thickness = 0.0
+cache/0/9/0/scale = 1.0
+cache/0/10/0/ascent = 0.0
+cache/0/10/0/descent = 0.0
+cache/0/10/0/underline_position = 0.0
+cache/0/10/0/underline_thickness = 0.0
+cache/0/10/0/scale = 1.0
+cache/0/15/0/ascent = 0.0
+cache/0/15/0/descent = 0.0
+cache/0/15/0/underline_position = 0.0
+cache/0/15/0/underline_thickness = 0.0
+cache/0/15/0/scale = 1.0
+
+[sub_resource type="FontFile" id="FontFile_6p666"]
+fallbacks = Array[Font]([ExtResource("3_meltj")])
+subpixel_positioning = 0
+msdf_pixel_range = 14
+msdf_size = 128
+cache/0/16/0/ascent = 0.0
+cache/0/16/0/descent = 0.0
+cache/0/16/0/underline_position = 0.0
+cache/0/16/0/underline_thickness = 0.0
+cache/0/16/0/scale = 1.0
+cache/0/50/0/ascent = 0.0
+cache/0/50/0/descent = 0.0
+cache/0/50/0/underline_position = 0.0
+cache/0/50/0/underline_thickness = 0.0
+cache/0/50/0/scale = 1.0
+cache/0/7/0/ascent = 0.0
+cache/0/7/0/descent = 0.0
+cache/0/7/0/underline_position = 0.0
+cache/0/7/0/underline_thickness = 0.0
+cache/0/7/0/scale = 1.0
+cache/0/8/0/ascent = 0.0
+cache/0/8/0/descent = 0.0
+cache/0/8/0/underline_position = 0.0
+cache/0/8/0/underline_thickness = 0.0
+cache/0/8/0/scale = 1.0
+cache/0/9/0/ascent = 0.0
+cache/0/9/0/descent = 0.0
+cache/0/9/0/underline_position = 0.0
+cache/0/9/0/underline_thickness = 0.0
+cache/0/9/0/scale = 1.0
+cache/0/10/0/ascent = 0.0
+cache/0/10/0/descent = 0.0
+cache/0/10/0/underline_position = 0.0
+cache/0/10/0/underline_thickness = 0.0
+cache/0/10/0/scale = 1.0
+cache/0/11/0/ascent = 0.0
+cache/0/11/0/descent = 0.0
+cache/0/11/0/underline_position = 0.0
+cache/0/11/0/underline_thickness = 0.0
+cache/0/11/0/scale = 1.0
+cache/0/15/0/ascent = 0.0
+cache/0/15/0/descent = 0.0
+cache/0/15/0/underline_position = 0.0
+cache/0/15/0/underline_thickness = 0.0
+cache/0/15/0/scale = 1.0
+cache/0/14/0/ascent = 0.0
+cache/0/14/0/descent = 0.0
+cache/0/14/0/underline_position = 0.0
+cache/0/14/0/underline_thickness = 0.0
+cache/0/14/0/scale = 1.0
+cache/0/13/0/ascent = 0.0
+cache/0/13/0/descent = 0.0
+cache/0/13/0/underline_position = 0.0
+cache/0/13/0/underline_thickness = 0.0
+cache/0/13/0/scale = 1.0
+cache/0/12/0/ascent = 0.0
+cache/0/12/0/descent = 0.0
+cache/0/12/0/underline_position = 0.0
+cache/0/12/0/underline_thickness = 0.0
+cache/0/12/0/scale = 1.0
 
 [node name="General" type="VBoxContainer"]
-margin_left = 8.0
-margin_top = 8.0
-margin_right = 312.0
-margin_bottom = 172.0
-custom_constants/separation = 1
-script = ExtResource( 1 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/separation = 1
+script = ExtResource("1")
 
 [node name="HBoxContainer" type="HBoxContainer" parent="."]
-margin_right = 304.0
-margin_bottom = 144.0
-rect_min_size = Vector2( 0, 106 )
-size_flags_horizontal = 3
+custom_minimum_size = Vector2(0, 106)
+layout_mode = 2
 size_flags_vertical = 3
 
 [node name="Panel" type="Panel" parent="HBoxContainer"]
-margin_right = 150.0
-margin_bottom = 144.0
+layout_mode = 2
 size_flags_horizontal = 3
-size_flags_vertical = 3
-custom_styles/panel = ExtResource( 2 )
+theme_override_styles/panel = ExtResource("2")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="HBoxContainer/Panel"]
+layout_mode = 1
+anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
 size_flags_vertical = 3
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="Resolution" type="Label" parent="HBoxContainer/Panel/VBoxContainer"]
-margin_right = 150.0
-margin_bottom = 34.0
+layout_mode = 2
 size_flags_horizontal = 5
 size_flags_vertical = 1
-custom_fonts/font = ExtResource( 3 )
+theme_override_fonts/font = SubResource("FontFile_4wxgj")
 text = "Resolution"
-align = 1
+horizontal_alignment = 1
 
 [node name="HBoxContainer" type="HBoxContainer" parent="HBoxContainer/Panel/VBoxContainer"]
-margin_left = 29.0
-margin_top = 38.0
-margin_right = 121.0
-margin_bottom = 100.0
+layout_mode = 2
 size_flags_horizontal = 4
 size_flags_vertical = 4
 
 [node name="VBoxContainer" type="VBoxContainer" parent="HBoxContainer/Panel/VBoxContainer/HBoxContainer"]
-margin_right = 88.0
-margin_bottom = 62.0
+layout_mode = 2
+size_flags_horizontal = 6
 size_flags_vertical = 3
 
-[node name="Fullscreen" parent="HBoxContainer/Panel/VBoxContainer/HBoxContainer/VBoxContainer" instance=ExtResource( 4 )]
-margin_right = 88.0
-margin_bottom = 18.0
-custom_fonts/font = ExtResource( 8 )
+[node name="Fullscreen" parent="HBoxContainer/Panel/VBoxContainer/HBoxContainer/VBoxContainer" instance=ExtResource("4")]
+layout_mode = 2
+theme_override_fonts/font = SubResource("FontFile_6p666")
 
-[node name="Borderless" parent="HBoxContainer/Panel/VBoxContainer/HBoxContainer/VBoxContainer" instance=ExtResource( 4 )]
-margin_top = 22.0
-margin_right = 88.0
-margin_bottom = 40.0
-custom_fonts/font = ExtResource( 8 )
+[node name="Borderless" parent="HBoxContainer/Panel/VBoxContainer/HBoxContainer/VBoxContainer" instance=ExtResource("4")]
+layout_mode = 2
+focus_neighbor_bottom = NodePath("../HBoxContainer/ScaleUp")
+theme_override_fonts/font = SubResource("FontFile_6p666")
 text = "Borderless"
 
 [node name="HBoxContainer" type="HBoxContainer" parent="HBoxContainer/Panel/VBoxContainer/HBoxContainer/VBoxContainer"]
-margin_top = 44.0
-margin_right = 88.0
-margin_bottom = 62.0
+layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
-[node name="ScaleDown" parent="HBoxContainer/Panel/VBoxContainer/HBoxContainer/VBoxContainer/HBoxContainer" instance=ExtResource( 5 )]
-margin_top = 1.0
-margin_right = 16.0
-margin_bottom = 17.0
-focus_neighbour_right = NodePath("../ScaleUp")
+[node name="ScaleDown" parent="HBoxContainer/Panel/VBoxContainer/HBoxContainer/VBoxContainer/HBoxContainer" instance=ExtResource("5")]
+layout_mode = 2
+focus_neighbor_right = NodePath("../ScaleUp")
 
 [node name="Label" parent="HBoxContainer/Panel/VBoxContainer/HBoxContainer/VBoxContainer/HBoxContainer/ScaleDown" index="0"]
 text = "-"
 
 [node name="Scale" type="Label" parent="HBoxContainer/Panel/VBoxContainer/HBoxContainer/VBoxContainer/HBoxContainer"]
-margin_left = 20.0
-margin_right = 68.0
-margin_bottom = 18.0
-rect_min_size = Vector2( 48, 0 )
+custom_minimum_size = Vector2(48, 0)
+layout_mode = 2
 size_flags_horizontal = 6
-custom_fonts/font = ExtResource( 8 )
+theme_override_fonts/font = SubResource("FontFile_6p666")
 text = "Scale"
-align = 1
+horizontal_alignment = 1
 
-[node name="ScaleUp" parent="HBoxContainer/Panel/VBoxContainer/HBoxContainer/VBoxContainer/HBoxContainer" instance=ExtResource( 5 )]
-margin_left = 72.0
-margin_top = 1.0
-margin_right = 88.0
-margin_bottom = 17.0
-focus_neighbour_left = NodePath("../ScaleDown")
-focus_neighbour_bottom = NodePath("../../../../../../../MarginContainer/VBoxContainer/Back")
+[node name="ScaleUp" parent="HBoxContainer/Panel/VBoxContainer/HBoxContainer/VBoxContainer/HBoxContainer" instance=ExtResource("5")]
+layout_mode = 2
+focus_neighbor_left = NodePath("../ScaleDown")
+focus_neighbor_top = NodePath("../../Borderless")
+focus_neighbor_bottom = NodePath("../../../../../../../MarginContainer/VBoxContainer/LanguagesButton")
 
 [node name="Margin" type="Control" parent="HBoxContainer/Panel/VBoxContainer/HBoxContainer"]
-margin_left = 92.0
-margin_right = 92.0
-margin_bottom = 62.0
+layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
 [node name="Panel2" type="Panel" parent="HBoxContainer"]
-margin_left = 154.0
-margin_right = 304.0
-margin_bottom = 144.0
+layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
-custom_styles/panel = ExtResource( 2 )
+theme_override_styles/panel = ExtResource("2")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="HBoxContainer/Panel2"]
+layout_mode = 1
+anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
 size_flags_vertical = 3
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="Volume" type="Label" parent="HBoxContainer/Panel2/VBoxContainer"]
-margin_right = 150.0
-margin_bottom = 34.0
+layout_mode = 2
 size_flags_horizontal = 5
 size_flags_vertical = 1
-custom_fonts/font = ExtResource( 3 )
+theme_override_fonts/font = SubResource("FontFile_4wxgj")
 text = "Volume"
-align = 1
+horizontal_alignment = 1
 
 [node name="MarginContainer" type="MarginContainer" parent="HBoxContainer/Panel2/VBoxContainer"]
-margin_top = 38.0
-margin_right = 150.0
-margin_bottom = 142.0
-custom_constants/margin_right = 4
-custom_constants/margin_left = 5
+layout_mode = 2
+size_flags_vertical = 3
+theme_override_constants/margin_left = 5
+theme_override_constants/margin_right = 4
 
 [node name="HBoxContainer" type="HBoxContainer" parent="HBoxContainer/Panel2/VBoxContainer/MarginContainer"]
-margin_left = 5.0
-margin_right = 146.0
-margin_bottom = 104.0
+layout_mode = 2
 size_flags_horizontal = 3
-size_flags_vertical = 3
+size_flags_vertical = 2
 
 [node name="VBoxContainer" type="VBoxContainer" parent="HBoxContainer/Panel2/VBoxContainer/MarginContainer/HBoxContainer"]
-margin_right = 141.0
-margin_bottom = 104.0
+layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
-[node name="Master" parent="HBoxContainer/Panel2/VBoxContainer/MarginContainer/HBoxContainer/VBoxContainer" instance=ExtResource( 7 )]
-margin_right = 141.0
+[node name="Master" parent="HBoxContainer/Panel2/VBoxContainer/MarginContainer/HBoxContainer/VBoxContainer" instance=ExtResource("7")]
+layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="ScaleName" parent="HBoxContainer/Panel2/VBoxContainer/MarginContainer/HBoxContainer/VBoxContainer/Master" index="0"]
-margin_right = 141.0
-
 [node name="HSlider" parent="HBoxContainer/Panel2/VBoxContainer/MarginContainer/HBoxContainer/VBoxContainer/Master" index="1"]
-margin_right = 141.0
+focus_neighbor_top = NodePath("../../../../../../../Panel/VBoxContainer/HBoxContainer/VBoxContainer/Fullscreen")
 
-[node name="Music" parent="HBoxContainer/Panel2/VBoxContainer/MarginContainer/HBoxContainer/VBoxContainer" instance=ExtResource( 7 )]
-margin_top = 36.0
-margin_right = 141.0
-margin_bottom = 68.0
+[node name="Music" parent="HBoxContainer/Panel2/VBoxContainer/MarginContainer/HBoxContainer/VBoxContainer" instance=ExtResource("7")]
+layout_mode = 2
 size_flags_horizontal = 3
 
 [node name="ScaleName" parent="HBoxContainer/Panel2/VBoxContainer/MarginContainer/HBoxContainer/VBoxContainer/Music" index="0"]
-margin_right = 141.0
 text = "Music"
 
 [node name="HSlider" parent="HBoxContainer/Panel2/VBoxContainer/MarginContainer/HBoxContainer/VBoxContainer/Music" index="1"]
-margin_right = 141.0
+focus_neighbor_top = NodePath("../../Master/HSlider")
+focus_neighbor_bottom = NodePath("../../SFX/HSlider")
 
 [node name="AudioStreamPlayer" parent="HBoxContainer/Panel2/VBoxContainer/MarginContainer/HBoxContainer/VBoxContainer/Music" index="2"]
-bus = "Music"
+bus = &"Music"
 
-[node name="SFX" parent="HBoxContainer/Panel2/VBoxContainer/MarginContainer/HBoxContainer/VBoxContainer" instance=ExtResource( 7 )]
-margin_top = 72.0
-margin_right = 141.0
-margin_bottom = 104.0
+[node name="SFX" parent="HBoxContainer/Panel2/VBoxContainer/MarginContainer/HBoxContainer/VBoxContainer" instance=ExtResource("7")]
+layout_mode = 2
 size_flags_horizontal = 3
 
 [node name="ScaleName" parent="HBoxContainer/Panel2/VBoxContainer/MarginContainer/HBoxContainer/VBoxContainer/SFX" index="0"]
-margin_right = 141.0
 text = "SFX"
 
 [node name="HSlider" parent="HBoxContainer/Panel2/VBoxContainer/MarginContainer/HBoxContainer/VBoxContainer/SFX" index="1"]
-margin_right = 141.0
-focus_neighbour_bottom = NodePath("../../../../../../../../MarginContainer/VBoxContainer/Controls")
+focus_neighbor_top = NodePath("../../Music/HSlider")
+focus_neighbor_bottom = NodePath("../../../../../../../../MarginContainer/VBoxContainer/Controls")
 
 [node name="AudioStreamPlayer" parent="HBoxContainer/Panel2/VBoxContainer/MarginContainer/HBoxContainer/VBoxContainer/SFX" index="2"]
-bus = "SFX"
+bus = &"SFX"
 
 [node name="MarginContainer" type="MarginContainer" parent="."]
-margin_top = 145.0
-margin_right = 304.0
-margin_bottom = 164.0
+layout_mode = 2
 size_flags_horizontal = 3
 
 [node name="VBoxContainer" type="HBoxContainer" parent="MarginContainer"]
-margin_right = 304.0
-margin_bottom = 19.0
+layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
-custom_constants/separation = 1
+theme_override_constants/separation = 1
 
 [node name="Control3" type="Control" parent="MarginContainer/VBoxContainer"]
-margin_right = 38.0
-margin_bottom = 19.0
+layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="Back" parent="MarginContainer/VBoxContainer" groups=[
-"General",
-] instance=ExtResource( 9 )]
-margin_left = 39.0
-margin_right = 77.0
+[node name="Back" parent="MarginContainer/VBoxContainer" groups=["General"] instance=ExtResource("9")]
+layout_mode = 2
 text = "Back"
 
 [node name="Control2" type="Control" parent="MarginContainer/VBoxContainer"]
-margin_left = 78.0
-margin_right = 116.0
-margin_bottom = 19.0
+layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="LanguagesButton" parent="MarginContainer/VBoxContainer" instance=ExtResource( 9 )]
-margin_left = 117.0
-margin_right = 176.0
+[node name="LanguagesButton" parent="MarginContainer/VBoxContainer" instance=ExtResource("9")]
+layout_mode = 2
+focus_neighbor_top = NodePath("../../../HBoxContainer/Panel/VBoxContainer/HBoxContainer/VBoxContainer/HBoxContainer/ScaleUp")
 text = "Languages"
 
 [node name="Control4" type="Control" parent="MarginContainer/VBoxContainer"]
-margin_left = 177.0
-margin_right = 215.0
-margin_bottom = 19.0
+layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="Controls" parent="MarginContainer/VBoxContainer" instance=ExtResource( 9 )]
-margin_left = 216.0
-margin_right = 265.0
+[node name="Controls" parent="MarginContainer/VBoxContainer" instance=ExtResource("9")]
+layout_mode = 2
+focus_neighbor_top = NodePath("../../../HBoxContainer/Panel2/VBoxContainer/MarginContainer/HBoxContainer/VBoxContainer/SFX/HSlider")
 text = "Controls"
 
 [node name="Control" type="Control" parent="MarginContainer/VBoxContainer"]
-margin_left = 266.0
-margin_right = 304.0
-margin_bottom = 19.0
+layout_mode = 2
 size_flags_horizontal = 3
 
 [connection signal="pressed" from="HBoxContainer/Panel/VBoxContainer/HBoxContainer/VBoxContainer/Fullscreen" to="." method="_on_Fullscreen_pressed"]

--- a/GameTemplate/addons/GameTemplate/GUI/OptionsSections/General.tscn
+++ b/GameTemplate/addons/GameTemplate/GUI/OptionsSections/General.tscn
@@ -73,6 +73,11 @@ cache/0/15/0/descent = 0.0
 cache/0/15/0/underline_position = 0.0
 cache/0/15/0/underline_thickness = 0.0
 cache/0/15/0/scale = 1.0
+cache/0/18/0/ascent = 0.0
+cache/0/18/0/descent = 0.0
+cache/0/18/0/underline_position = 0.0
+cache/0/18/0/underline_thickness = 0.0
+cache/0/18/0/scale = 1.0
 
 [sub_resource type="FontFile" id="FontFile_6p666"]
 fallbacks = Array[Font]([ExtResource("3_meltj")])
@@ -134,6 +139,11 @@ cache/0/12/0/descent = 0.0
 cache/0/12/0/underline_position = 0.0
 cache/0/12/0/underline_thickness = 0.0
 cache/0/12/0/scale = 1.0
+cache/0/18/0/ascent = 0.0
+cache/0/18/0/descent = 0.0
+cache/0/18/0/underline_position = 0.0
+cache/0/18/0/underline_thickness = 0.0
+cache/0/18/0/scale = 1.0
 
 [node name="General" type="VBoxContainer"]
 anchors_preset = 15
@@ -168,6 +178,7 @@ layout_mode = 2
 size_flags_horizontal = 5
 size_flags_vertical = 1
 theme_override_fonts/font = SubResource("FontFile_4wxgj")
+theme_override_font_sizes/font_size = 18
 text = "Resolution"
 horizontal_alignment = 1
 
@@ -193,7 +204,7 @@ text = "Borderless"
 
 [node name="HBoxContainer" type="HBoxContainer" parent="HBoxContainer/Panel/VBoxContainer/HBoxContainer/VBoxContainer"]
 layout_mode = 2
-size_flags_horizontal = 3
+size_flags_horizontal = 6
 size_flags_vertical = 3
 
 [node name="ScaleDown" parent="HBoxContainer/Panel/VBoxContainer/HBoxContainer/VBoxContainer/HBoxContainer" instance=ExtResource("5")]
@@ -206,8 +217,8 @@ text = "-"
 [node name="Scale" type="Label" parent="HBoxContainer/Panel/VBoxContainer/HBoxContainer/VBoxContainer/HBoxContainer"]
 custom_minimum_size = Vector2(48, 0)
 layout_mode = 2
-size_flags_horizontal = 6
 theme_override_fonts/font = SubResource("FontFile_6p666")
+theme_override_font_sizes/font_size = 18
 text = "Scale"
 horizontal_alignment = 1
 
@@ -242,6 +253,7 @@ layout_mode = 2
 size_flags_horizontal = 5
 size_flags_vertical = 1
 theme_override_fonts/font = SubResource("FontFile_4wxgj")
+theme_override_font_sizes/font_size = 18
 text = "Volume"
 horizontal_alignment = 1
 
@@ -265,6 +277,9 @@ size_flags_vertical = 3
 layout_mode = 2
 size_flags_horizontal = 3
 
+[node name="ScaleName" parent="HBoxContainer/Panel2/VBoxContainer/MarginContainer/HBoxContainer/VBoxContainer/Master" index="0"]
+theme_override_font_sizes/font_size = 18
+
 [node name="HSlider" parent="HBoxContainer/Panel2/VBoxContainer/MarginContainer/HBoxContainer/VBoxContainer/Master" index="1"]
 focus_neighbor_top = NodePath("../../../../../../../Panel/VBoxContainer/HBoxContainer/VBoxContainer/Fullscreen")
 
@@ -273,6 +288,7 @@ layout_mode = 2
 size_flags_horizontal = 3
 
 [node name="ScaleName" parent="HBoxContainer/Panel2/VBoxContainer/MarginContainer/HBoxContainer/VBoxContainer/Music" index="0"]
+theme_override_font_sizes/font_size = 18
 text = "Music"
 
 [node name="HSlider" parent="HBoxContainer/Panel2/VBoxContainer/MarginContainer/HBoxContainer/VBoxContainer/Music" index="1"]
@@ -287,6 +303,7 @@ layout_mode = 2
 size_flags_horizontal = 3
 
 [node name="ScaleName" parent="HBoxContainer/Panel2/VBoxContainer/MarginContainer/HBoxContainer/VBoxContainer/SFX" index="0"]
+theme_override_font_sizes/font_size = 18
 text = "SFX"
 
 [node name="HSlider" parent="HBoxContainer/Panel2/VBoxContainer/MarginContainer/HBoxContainer/VBoxContainer/SFX" index="1"]

--- a/GameTemplate/addons/GameTemplate/GUI/OptionsSections/General.tscn
+++ b/GameTemplate/addons/GameTemplate/GUI/OptionsSections/General.tscn
@@ -198,23 +198,23 @@ theme_override_fonts/font = SubResource("FontFile_6p666")
 
 [node name="Borderless" parent="HBoxContainer/Panel/VBoxContainer/HBoxContainer/VBoxContainer" instance=ExtResource("4")]
 layout_mode = 2
-focus_neighbor_bottom = NodePath("../HBoxContainer/ScaleUp")
+focus_neighbor_bottom = NodePath("../ScaleGroup/ScaleUp")
 theme_override_fonts/font = SubResource("FontFile_6p666")
 text = "Borderless"
 
-[node name="HBoxContainer" type="HBoxContainer" parent="HBoxContainer/Panel/VBoxContainer/HBoxContainer/VBoxContainer"]
+[node name="ScaleGroup" type="HBoxContainer" parent="HBoxContainer/Panel/VBoxContainer/HBoxContainer/VBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 6
 size_flags_vertical = 3
 
-[node name="ScaleDown" parent="HBoxContainer/Panel/VBoxContainer/HBoxContainer/VBoxContainer/HBoxContainer" instance=ExtResource("5")]
+[node name="ScaleDown" parent="HBoxContainer/Panel/VBoxContainer/HBoxContainer/VBoxContainer/ScaleGroup" instance=ExtResource("5")]
 layout_mode = 2
 focus_neighbor_right = NodePath("../ScaleUp")
 
-[node name="Label" parent="HBoxContainer/Panel/VBoxContainer/HBoxContainer/VBoxContainer/HBoxContainer/ScaleDown" index="0"]
+[node name="Label" parent="HBoxContainer/Panel/VBoxContainer/HBoxContainer/VBoxContainer/ScaleGroup/ScaleDown" index="0"]
 text = "-"
 
-[node name="Scale" type="Label" parent="HBoxContainer/Panel/VBoxContainer/HBoxContainer/VBoxContainer/HBoxContainer"]
+[node name="Scale" type="Label" parent="HBoxContainer/Panel/VBoxContainer/HBoxContainer/VBoxContainer/ScaleGroup"]
 custom_minimum_size = Vector2(48, 0)
 layout_mode = 2
 theme_override_fonts/font = SubResource("FontFile_6p666")
@@ -222,7 +222,7 @@ theme_override_font_sizes/font_size = 18
 text = "Scale"
 horizontal_alignment = 1
 
-[node name="ScaleUp" parent="HBoxContainer/Panel/VBoxContainer/HBoxContainer/VBoxContainer/HBoxContainer" instance=ExtResource("5")]
+[node name="ScaleUp" parent="HBoxContainer/Panel/VBoxContainer/HBoxContainer/VBoxContainer/ScaleGroup" instance=ExtResource("5")]
 layout_mode = 2
 focus_neighbor_left = NodePath("../ScaleDown")
 focus_neighbor_top = NodePath("../../Borderless")
@@ -329,6 +329,7 @@ size_flags_horizontal = 3
 
 [node name="Back" parent="MarginContainer/VBoxContainer" groups=["General"] instance=ExtResource("9")]
 layout_mode = 2
+focus_neighbor_right = NodePath("../LanguagesButton")
 text = "Back"
 
 [node name="Control2" type="Control" parent="MarginContainer/VBoxContainer"]
@@ -337,7 +338,8 @@ size_flags_horizontal = 3
 
 [node name="LanguagesButton" parent="MarginContainer/VBoxContainer" instance=ExtResource("9")]
 layout_mode = 2
-focus_neighbor_top = NodePath("../../../HBoxContainer/Panel/VBoxContainer/HBoxContainer/VBoxContainer/HBoxContainer/ScaleUp")
+focus_neighbor_left = NodePath("../Back")
+focus_neighbor_top = NodePath("../../../HBoxContainer/Panel/VBoxContainer/HBoxContainer/VBoxContainer/ScaleGroup/ScaleUp")
 text = "Languages"
 
 [node name="Control4" type="Control" parent="MarginContainer/VBoxContainer"]
@@ -355,8 +357,8 @@ size_flags_horizontal = 3
 
 [connection signal="pressed" from="HBoxContainer/Panel/VBoxContainer/HBoxContainer/VBoxContainer/Fullscreen" to="." method="_on_Fullscreen_pressed"]
 [connection signal="pressed" from="HBoxContainer/Panel/VBoxContainer/HBoxContainer/VBoxContainer/Borderless" to="." method="_on_Borderless_pressed"]
-[connection signal="pressed" from="HBoxContainer/Panel/VBoxContainer/HBoxContainer/VBoxContainer/HBoxContainer/ScaleDown" to="." method="_on_ScaleDown_pressed"]
-[connection signal="pressed" from="HBoxContainer/Panel/VBoxContainer/HBoxContainer/VBoxContainer/HBoxContainer/ScaleUp" to="." method="_on_ScaleUp_pressed"]
+[connection signal="pressed" from="HBoxContainer/Panel/VBoxContainer/HBoxContainer/VBoxContainer/ScaleGroup/ScaleDown" to="." method="_on_ScaleDown_pressed"]
+[connection signal="pressed" from="HBoxContainer/Panel/VBoxContainer/HBoxContainer/VBoxContainer/ScaleGroup/ScaleUp" to="." method="_on_ScaleUp_pressed"]
 [connection signal="value_changed" from="HBoxContainer/Panel2/VBoxContainer/MarginContainer/HBoxContainer/VBoxContainer/Master/HSlider" to="." method="_on_Master_value_changed"]
 [connection signal="value_changed" from="HBoxContainer/Panel2/VBoxContainer/MarginContainer/HBoxContainer/VBoxContainer/Music/HSlider" to="." method="_on_Music_value_changed"]
 [connection signal="value_changed" from="HBoxContainer/Panel2/VBoxContainer/MarginContainer/HBoxContainer/VBoxContainer/SFX/HSlider" to="." method="_on_SFX_value_changed"]
@@ -364,7 +366,7 @@ size_flags_horizontal = 3
 [connection signal="pressed" from="MarginContainer/VBoxContainer/LanguagesButton" to="." method="_on_Languages_pressed"]
 [connection signal="pressed" from="MarginContainer/VBoxContainer/Controls" to="." method="_on_Controls_pressed"]
 
-[editable path="HBoxContainer/Panel/VBoxContainer/HBoxContainer/VBoxContainer/HBoxContainer/ScaleDown"]
+[editable path="HBoxContainer/Panel/VBoxContainer/HBoxContainer/VBoxContainer/ScaleGroup/ScaleDown"]
 [editable path="HBoxContainer/Panel2/VBoxContainer/MarginContainer/HBoxContainer/VBoxContainer/Master"]
 [editable path="HBoxContainer/Panel2/VBoxContainer/MarginContainer/HBoxContainer/VBoxContainer/Music"]
 [editable path="HBoxContainer/Panel2/VBoxContainer/MarginContainer/HBoxContainer/VBoxContainer/SFX"]

--- a/GameTemplate/addons/GameTemplate/GUI/OptionsSections/General.tscn
+++ b/GameTemplate/addons/GameTemplate/GUI/OptionsSections/General.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource type="Script" path="res://addons/GameTemplate/GUI/OptionsSections/General.gd" id="1"]
 [ext_resource type="StyleBox" path="res://addons/GameTemplate/GUI/OptionsSections/DarkerPanel.tres" id="2"]
-[ext_resource type="FontFile" uid="uid://cj1os0is1qn2h" path="res://addons/GameTemplate/Assets/Fonts/pixellocale-v-1-4.ttf" id="3_meltj"]
+[ext_resource type="FontFile" uid="uid://2b17u8f57klu" path="res://addons/GameTemplate/Assets/Fonts/pixellocale-v-1-4.ttf" id="3_meltj"]
 [ext_resource type="PackedScene" uid="uid://jepfs4ovtw3x" path="res://addons/GameTemplate/GUI/Buttons/ToggleButton.tscn" id="4"]
 [ext_resource type="PackedScene" uid="uid://cirbjhf3pq0am" path="res://addons/GameTemplate/GUI/Buttons/TextureButton.tscn" id="5"]
 [ext_resource type="PackedScene" uid="uid://bfab4a8yhcgje" path="res://addons/GameTemplate/GUI/Buttons/OptionsSlider.tscn" id="7"]

--- a/GameTemplate/addons/GameTemplate/GUI/OptionsSections/Languages.gd
+++ b/GameTemplate/addons/GameTemplate/GUI/OptionsSections/Languages.gd
@@ -2,29 +2,29 @@ extends VBoxContainer
 
 signal Language_choosen
 
-onready var button:PackedScene = preload("res://addons/GameTemplate/GUI/Buttons/DefaultButton.tscn")
-onready var button_parent:HBoxContainer = $"Panel/VBoxContainer/MarginContainer/HBoxContainer"
+@onready var button:PackedScene = preload("res://addons/GameTemplate/GUI/Buttons/DefaultButton.tscn")
+@onready var button_parent:GridContainer = $"Panel/VBoxContainer/MarginContainer/HBoxContainer"
 
 func _ready()->void:
-	MenuEvent.connect("Languages", self, "on_show_languages")
-	MenuEvent.Languages = false #just in case project saved with visible Languages
+	MenuEvent.connect("LanguagesSignal", on_show_languages)
+	MenuEvent.Languages_val = false #just in case project saved with visible Languages
 	
 	for language in SettingsLanguage.Language_list:			#For each language generate button
-		var newButton:Button = button.instance()
+		var newButton:Button = button.instantiate()
 		button_parent.add_child(newButton)
 		newButton.text = "\"" + language + "\""
-		newButton.connect("pressed", self, "_on_language_pressed", [language])
+		newButton.connect("pressed", _on_language_pressed.bind(language))
 	
 	#Localization
-	SettingsLanguage.connect("ReTranslate", self, "retranslate")
+	SettingsLanguage.connect("ReTranslate", retranslate)
 	retranslate()
 
 func _on_language_pressed(value:String)->void:
 	SettingsLanguage.Language = SettingsLanguage.Language_dictionary[value] #Settings will emit ReTranslate signal
-	MenuEvent.Languages = false
+	MenuEvent.Languages_val = false
 
 func _on_Back_pressed()->void:
-	MenuEvent.Languages = false
+	MenuEvent.Languages_val = false
 
 #EVENT SIGNALS
 func on_show_languages(value:bool)->void:
@@ -34,4 +34,4 @@ func on_show_languages(value:bool)->void:
 
 #Localization
 func retranslate()->void:
-	find_node("Back").text = tr("BACK")
+	find_child("Back").text = tr("BACK")

--- a/GameTemplate/addons/GameTemplate/GUI/OptionsSections/Languages.tscn
+++ b/GameTemplate/addons/GameTemplate/GUI/OptionsSections/Languages.tscn
@@ -1,81 +1,139 @@
-[gd_scene load_steps=5 format=2]
+[gd_scene load_steps=6 format=3 uid="uid://dv20udv56ebyy"]
 
-[ext_resource path="res://addons/GameTemplate/GUI/OptionsSections/DarkerPanel.tres" type="StyleBox" id=1]
-[ext_resource path="res://addons/GameTemplate/GUI/OptionsSections/Languages.gd" type="Script" id=2]
-[ext_resource path="res://addons/GameTemplate/Assets/Fonts/pixellocale_16.tres" type="DynamicFont" id=3]
-[ext_resource path="res://addons/GameTemplate/GUI/Buttons/DefaultButton.tscn" type="PackedScene" id=6]
+[ext_resource type="StyleBox" path="res://addons/GameTemplate/GUI/OptionsSections/DarkerPanel.tres" id="1"]
+[ext_resource type="Script" path="res://addons/GameTemplate/GUI/OptionsSections/Languages.gd" id="2"]
+[ext_resource type="FontFile" uid="uid://cj1os0is1qn2h" path="res://addons/GameTemplate/Assets/Fonts/pixellocale-v-1-4.ttf" id="3_8w2nd"]
+[ext_resource type="PackedScene" uid="uid://dp81qs74tu3ba" path="res://addons/GameTemplate/GUI/Buttons/DefaultButton.tscn" id="6"]
+
+[sub_resource type="FontFile" id="FontFile_4wxgj"]
+fallbacks = Array[Font]([ExtResource("3_8w2nd")])
+subpixel_positioning = 0
+msdf_pixel_range = 14
+msdf_size = 128
+cache/0/16/0/ascent = 0.0
+cache/0/16/0/descent = 0.0
+cache/0/16/0/underline_position = 0.0
+cache/0/16/0/underline_thickness = 0.0
+cache/0/16/0/scale = 1.0
+cache/0/50/0/ascent = 0.0
+cache/0/50/0/descent = 0.0
+cache/0/50/0/underline_position = 0.0
+cache/0/50/0/underline_thickness = 0.0
+cache/0/50/0/scale = 1.0
+cache/0/2/0/ascent = 0.0
+cache/0/2/0/descent = 0.0
+cache/0/2/0/underline_position = 0.0
+cache/0/2/0/underline_thickness = 0.0
+cache/0/2/0/scale = 1.0
+cache/0/3/0/ascent = 0.0
+cache/0/3/0/descent = 0.0
+cache/0/3/0/underline_position = 0.0
+cache/0/3/0/underline_thickness = 0.0
+cache/0/3/0/scale = 1.0
+cache/0/4/0/ascent = 0.0
+cache/0/4/0/descent = 0.0
+cache/0/4/0/underline_position = 0.0
+cache/0/4/0/underline_thickness = 0.0
+cache/0/4/0/scale = 1.0
+cache/0/5/0/ascent = 0.0
+cache/0/5/0/descent = 0.0
+cache/0/5/0/underline_position = 0.0
+cache/0/5/0/underline_thickness = 0.0
+cache/0/5/0/scale = 1.0
+cache/0/6/0/ascent = 0.0
+cache/0/6/0/descent = 0.0
+cache/0/6/0/underline_position = 0.0
+cache/0/6/0/underline_thickness = 0.0
+cache/0/6/0/scale = 1.0
+cache/0/7/0/ascent = 0.0
+cache/0/7/0/descent = 0.0
+cache/0/7/0/underline_position = 0.0
+cache/0/7/0/underline_thickness = 0.0
+cache/0/7/0/scale = 1.0
+cache/0/8/0/ascent = 0.0
+cache/0/8/0/descent = 0.0
+cache/0/8/0/underline_position = 0.0
+cache/0/8/0/underline_thickness = 0.0
+cache/0/8/0/scale = 1.0
+cache/0/9/0/ascent = 0.0
+cache/0/9/0/descent = 0.0
+cache/0/9/0/underline_position = 0.0
+cache/0/9/0/underline_thickness = 0.0
+cache/0/9/0/scale = 1.0
+cache/0/10/0/ascent = 0.0
+cache/0/10/0/descent = 0.0
+cache/0/10/0/underline_position = 0.0
+cache/0/10/0/underline_thickness = 0.0
+cache/0/10/0/scale = 1.0
+cache/0/15/0/ascent = 0.0
+cache/0/15/0/descent = 0.0
+cache/0/15/0/underline_position = 0.0
+cache/0/15/0/underline_thickness = 0.0
+cache/0/15/0/scale = 1.0
 
 [node name="Languages" type="VBoxContainer"]
-margin_left = 8.0
-margin_top = 8.0
-margin_right = 312.0
-margin_bottom = 172.0
-custom_constants/separation = 1
-script = ExtResource( 2 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -240.0
+offset_top = -135.0
+offset_right = 240.0
+offset_bottom = 135.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/separation = 1
+script = ExtResource("2")
 
 [node name="Panel" type="Panel" parent="."]
-margin_right = 304.0
-margin_bottom = 144.0
+layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
-custom_styles/panel = ExtResource( 1 )
+theme_override_styles/panel = ExtResource("1")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="Panel"]
+layout_mode = 0
 anchor_right = 1.0
 anchor_bottom = 1.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="LanguagesLabel" type="Label" parent="Panel/VBoxContainer"]
-margin_right = 304.0
-margin_bottom = 34.0
+layout_mode = 2
 size_flags_horizontal = 5
 size_flags_vertical = 1
-custom_fonts/font = ExtResource( 3 )
+theme_override_fonts/font = SubResource("FontFile_4wxgj")
 text = "Languages"
-align = 1
+horizontal_alignment = 1
 
 [node name="MarginContainer" type="MarginContainer" parent="Panel/VBoxContainer"]
-margin_top = 38.0
-margin_right = 304.0
-margin_bottom = 144.0
+layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
-custom_constants/margin_right = 4
-custom_constants/margin_top = 4
-custom_constants/margin_left = 5
-custom_constants/margin_bottom = 4
+theme_override_constants/margin_left = 5
+theme_override_constants/margin_top = 4
+theme_override_constants/margin_right = 4
+theme_override_constants/margin_bottom = 4
 
-[node name="HBoxContainer" type="HBoxContainer" parent="Panel/VBoxContainer/MarginContainer"]
-margin_left = 5.0
-margin_top = 4.0
-margin_right = 300.0
-margin_bottom = 102.0
+[node name="HBoxContainer" type="GridContainer" parent="Panel/VBoxContainer/MarginContainer"]
+layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 4
+columns = 4
 
 [node name="MarginContainer" type="MarginContainer" parent="."]
-margin_top = 145.0
-margin_right = 304.0
-margin_bottom = 164.0
+layout_mode = 2
 size_flags_horizontal = 3
 
 [node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer"]
-margin_left = 137.0
-margin_right = 166.0
-margin_bottom = 19.0
+layout_mode = 2
 size_flags_horizontal = 4
 size_flags_vertical = 3
-custom_constants/separation = 1
+theme_override_constants/separation = 1
 
-[node name="Back" parent="MarginContainer/VBoxContainer" groups=[
-"Languages",
-] instance=ExtResource( 6 )]
-margin_right = 29.0
+[node name="Back" parent="MarginContainer/VBoxContainer" groups=["Languages"] instance=ExtResource("6")]
+layout_mode = 2
 text = "Back"
 
 [connection signal="pressed" from="MarginContainer/VBoxContainer/Back" to="." method="_on_Back_pressed"]

--- a/GameTemplate/addons/GameTemplate/GUI/OptionsSections/Languages.tscn
+++ b/GameTemplate/addons/GameTemplate/GUI/OptionsSections/Languages.tscn
@@ -2,79 +2,12 @@
 
 [ext_resource type="StyleBox" path="res://addons/GameTemplate/GUI/OptionsSections/DarkerPanel.tres" id="1"]
 [ext_resource type="Script" path="res://addons/GameTemplate/GUI/OptionsSections/Languages.gd" id="2"]
-[ext_resource type="FontFile" uid="uid://cj1os0is1qn2h" path="res://addons/GameTemplate/Assets/Fonts/pixellocale-v-1-4.ttf" id="3_8w2nd"]
+[ext_resource type="FontFile" uid="uid://c5gjw5i0akjja" path="res://Assets/Fonts/pixellocale-v-1-4.ttf" id="3_xqlkr"]
 [ext_resource type="PackedScene" uid="uid://dp81qs74tu3ba" path="res://addons/GameTemplate/GUI/Buttons/DefaultButton.tscn" id="6"]
 
-[sub_resource type="FontFile" id="FontFile_4wxgj"]
-fallbacks = Array[Font]([ExtResource("3_8w2nd")])
-subpixel_positioning = 0
-msdf_pixel_range = 14
-msdf_size = 128
-cache/0/16/0/ascent = 0.0
-cache/0/16/0/descent = 0.0
-cache/0/16/0/underline_position = 0.0
-cache/0/16/0/underline_thickness = 0.0
-cache/0/16/0/scale = 1.0
-cache/0/50/0/ascent = 0.0
-cache/0/50/0/descent = 0.0
-cache/0/50/0/underline_position = 0.0
-cache/0/50/0/underline_thickness = 0.0
-cache/0/50/0/scale = 1.0
-cache/0/2/0/ascent = 0.0
-cache/0/2/0/descent = 0.0
-cache/0/2/0/underline_position = 0.0
-cache/0/2/0/underline_thickness = 0.0
-cache/0/2/0/scale = 1.0
-cache/0/3/0/ascent = 0.0
-cache/0/3/0/descent = 0.0
-cache/0/3/0/underline_position = 0.0
-cache/0/3/0/underline_thickness = 0.0
-cache/0/3/0/scale = 1.0
-cache/0/4/0/ascent = 0.0
-cache/0/4/0/descent = 0.0
-cache/0/4/0/underline_position = 0.0
-cache/0/4/0/underline_thickness = 0.0
-cache/0/4/0/scale = 1.0
-cache/0/5/0/ascent = 0.0
-cache/0/5/0/descent = 0.0
-cache/0/5/0/underline_position = 0.0
-cache/0/5/0/underline_thickness = 0.0
-cache/0/5/0/scale = 1.0
-cache/0/6/0/ascent = 0.0
-cache/0/6/0/descent = 0.0
-cache/0/6/0/underline_position = 0.0
-cache/0/6/0/underline_thickness = 0.0
-cache/0/6/0/scale = 1.0
-cache/0/7/0/ascent = 0.0
-cache/0/7/0/descent = 0.0
-cache/0/7/0/underline_position = 0.0
-cache/0/7/0/underline_thickness = 0.0
-cache/0/7/0/scale = 1.0
-cache/0/8/0/ascent = 0.0
-cache/0/8/0/descent = 0.0
-cache/0/8/0/underline_position = 0.0
-cache/0/8/0/underline_thickness = 0.0
-cache/0/8/0/scale = 1.0
-cache/0/9/0/ascent = 0.0
-cache/0/9/0/descent = 0.0
-cache/0/9/0/underline_position = 0.0
-cache/0/9/0/underline_thickness = 0.0
-cache/0/9/0/scale = 1.0
-cache/0/10/0/ascent = 0.0
-cache/0/10/0/descent = 0.0
-cache/0/10/0/underline_position = 0.0
-cache/0/10/0/underline_thickness = 0.0
-cache/0/10/0/scale = 1.0
-cache/0/15/0/ascent = 0.0
-cache/0/15/0/descent = 0.0
-cache/0/15/0/underline_position = 0.0
-cache/0/15/0/underline_thickness = 0.0
-cache/0/15/0/scale = 1.0
-cache/0/18/0/ascent = 0.0
-cache/0/18/0/descent = 0.0
-cache/0/18/0/underline_position = 0.0
-cache/0/18/0/underline_thickness = 0.0
-cache/0/18/0/scale = 1.0
+[sub_resource type="LabelSettings" id="LabelSettings_cbrlp"]
+font = ExtResource("3_xqlkr")
+font_size = 18
 
 [node name="Languages" type="VBoxContainer"]
 anchors_preset = 8
@@ -108,9 +41,8 @@ size_flags_vertical = 3
 layout_mode = 2
 size_flags_horizontal = 5
 size_flags_vertical = 1
-theme_override_fonts/font = SubResource("FontFile_4wxgj")
-theme_override_font_sizes/font_size = 18
 text = "Languages"
+label_settings = SubResource("LabelSettings_cbrlp")
 horizontal_alignment = 1
 
 [node name="MarginContainer" type="MarginContainer" parent="Panel/VBoxContainer"]

--- a/GameTemplate/addons/GameTemplate/GUI/OptionsSections/Languages.tscn
+++ b/GameTemplate/addons/GameTemplate/GUI/OptionsSections/Languages.tscn
@@ -70,6 +70,11 @@ cache/0/15/0/descent = 0.0
 cache/0/15/0/underline_position = 0.0
 cache/0/15/0/underline_thickness = 0.0
 cache/0/15/0/scale = 1.0
+cache/0/18/0/ascent = 0.0
+cache/0/18/0/descent = 0.0
+cache/0/18/0/underline_position = 0.0
+cache/0/18/0/underline_thickness = 0.0
+cache/0/18/0/scale = 1.0
 
 [node name="Languages" type="VBoxContainer"]
 anchors_preset = 8
@@ -104,6 +109,7 @@ layout_mode = 2
 size_flags_horizontal = 5
 size_flags_vertical = 1
 theme_override_fonts/font = SubResource("FontFile_4wxgj")
+theme_override_font_sizes/font_size = 18
 text = "Languages"
 horizontal_alignment = 1
 

--- a/GameTemplate/addons/GameTemplate/GUI/ReBindSection/ActionBind.tscn
+++ b/GameTemplate/addons/GameTemplate/GUI/ReBindSection/ActionBind.tscn
@@ -32,6 +32,7 @@ theme_override_styles/panel = SubResource("1")
 [node name="Name" type="Label" parent="HBoxContainer/PanelContainer"]
 layout_mode = 2
 theme_override_fonts/font = ExtResource("1")
+theme_override_font_sizes/font_size = 18
 text = "Action"
 
 [node name="AddAction" type="Button" parent="HBoxContainer" groups=["ContainerFocus"]]
@@ -41,6 +42,7 @@ theme_override_colors/font_hover_color = Color(1, 1, 1, 1)
 theme_override_colors/font_pressed_color = Color(1, 1, 1, 1)
 theme_override_colors/font_color = Color(0.752941, 0.752941, 0.752941, 1)
 theme_override_fonts/font = ExtResource("1")
+theme_override_font_sizes/font_size = 18
 theme_override_styles/focus = ExtResource("4")
 theme_override_styles/disabled = ExtResource("2")
 theme_override_styles/hover = ExtResource("4")

--- a/GameTemplate/addons/GameTemplate/GUI/ReBindSection/ActionBind.tscn
+++ b/GameTemplate/addons/GameTemplate/GUI/ReBindSection/ActionBind.tscn
@@ -1,68 +1,49 @@
-[gd_scene load_steps=7 format=2]
+[gd_scene load_steps=6 format=3 uid="uid://br0cgmtk1jhtu"]
 
-[ext_resource path="res://addons/GameTemplate/Assets/Fonts/pixellocale_8.tres" type="DynamicFont" id=1]
-[ext_resource path="res://addons/GameTemplate/GUI/ReBindSection/AddActionStyle_Normal.tres" type="StyleBox" id=2]
-[ext_resource path="res://addons/GameTemplate/GUI/ReBindSection/AddActionStyle_Pressed.tres" type="StyleBox" id=3]
-[ext_resource path="res://addons/GameTemplate/GUI/ReBindSection/AddActionStyle_Hover.tres" type="StyleBox" id=4]
+[ext_resource type="FontFile" path="res://addons/GameTemplate/Assets/Fonts/pixellocale_8.tres" id="1"]
+[ext_resource type="StyleBox" path="res://addons/GameTemplate/GUI/ReBindSection/AddActionStyle_Normal.tres" id="2"]
+[ext_resource type="StyleBox" path="res://addons/GameTemplate/GUI/ReBindSection/AddActionStyle_Pressed.tres" id="3"]
+[ext_resource type="StyleBox" path="res://addons/GameTemplate/GUI/ReBindSection/AddActionStyle_Hover.tres" id="4"]
 
-[sub_resource type="StyleBoxFlat" id=1]
+[sub_resource type="StyleBoxFlat" id="1"]
 content_margin_left = 8.0
 content_margin_top = 0.0
 content_margin_bottom = 2.0
-bg_color = Color( 0.14902, 0.168627, 0.266667, 1 )
-corner_detail = 1
-anti_aliasing = false
-
-[sub_resource type="StyleBoxFlat" id=2]
-content_margin_left = 4.0
-content_margin_right = 3.0
-bg_color = Color( 0.227451, 0.266667, 0.4, 1 )
-draw_center = false
+bg_color = Color(0.14902, 0.168627, 0.266667, 1)
 corner_detail = 1
 anti_aliasing = false
 
 [node name="Action" type="VBoxContainer"]
-margin_right = 310.0
-margin_bottom = 13.0
-custom_constants/separation = 0
-__meta__ = {
-"_edit_use_anchors_": false
-}
+offset_right = 310.0
+offset_bottom = 13.0
+theme_override_constants/separation = 0
 
 [node name="HBoxContainer" type="HBoxContainer" parent="."]
-margin_right = 310.0
-margin_bottom = 20.0
+layout_mode = 2
 size_flags_horizontal = 3
-custom_constants/separation = 0
+theme_override_constants/separation = 0
 
 [node name="PanelContainer" type="PanelContainer" parent="HBoxContainer"]
-margin_right = 298.0
-margin_bottom = 20.0
+layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 0
-custom_styles/panel = SubResource( 1 )
+theme_override_styles/panel = SubResource("1")
 
 [node name="Name" type="Label" parent="HBoxContainer/PanelContainer"]
-margin_left = 8.0
-margin_right = 298.0
-margin_bottom = 18.0
-custom_fonts/font = ExtResource( 1 )
+layout_mode = 2
+theme_override_fonts/font = ExtResource("1")
 text = "Action"
 
-[node name="AddAction" type="Button" parent="HBoxContainer" groups=[
-"ContainerFocus",
-]]
-margin_left = 298.0
-margin_right = 310.0
-margin_bottom = 20.0
-hint_tooltip = "Add new control bind for this action"
-custom_styles/hover = ExtResource( 4 )
-custom_styles/pressed = ExtResource( 3 )
-custom_styles/focus = SubResource( 2 )
-custom_styles/disabled = ExtResource( 2 )
-custom_styles/normal = ExtResource( 2 )
-custom_fonts/font = ExtResource( 1 )
-custom_colors/font_color = Color( 0.752941, 0.752941, 0.752941, 1 )
-custom_colors/font_color_hover = Color( 1, 1, 1, 1 )
-custom_colors/font_color_pressed = Color( 1, 1, 1, 1 )
+[node name="AddAction" type="Button" parent="HBoxContainer" groups=["ContainerFocus"]]
+layout_mode = 2
+tooltip_text = "Add new control bind for this action"
+theme_override_colors/font_hover_color = Color(1, 1, 1, 1)
+theme_override_colors/font_pressed_color = Color(1, 1, 1, 1)
+theme_override_colors/font_color = Color(0.752941, 0.752941, 0.752941, 1)
+theme_override_fonts/font = ExtResource("1")
+theme_override_styles/focus = ExtResource("4")
+theme_override_styles/disabled = ExtResource("2")
+theme_override_styles/hover = ExtResource("4")
+theme_override_styles/pressed = ExtResource("3")
+theme_override_styles/normal = ExtResource("2")
 text = "+"

--- a/GameTemplate/addons/GameTemplate/GUI/ReBindSection/ControlBind.tscn
+++ b/GameTemplate/addons/GameTemplate/GUI/ReBindSection/ControlBind.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=7 format=3 uid="uid://bbq38gdhhvg6i"]
+[gd_scene load_steps=8 format=3 uid="uid://bbq38gdhhvg6i"]
 
-[ext_resource type="FontFile" uid="uid://cj1os0is1qn2h" path="res://addons/GameTemplate/Assets/Fonts/pixellocale-v-1-4.ttf" id="1_nh66a"]
+[ext_resource type="FontFile" uid="uid://c5gjw5i0akjja" path="res://Assets/Fonts/pixellocale-v-1-4.ttf" id="1_e6q6x"]
+[ext_resource type="FontFile" uid="uid://2b17u8f57klu" path="res://addons/GameTemplate/Assets/Fonts/pixellocale-v-1-4.ttf" id="1_nh66a"]
 [ext_resource type="StyleBox" uid="uid://cwcup4b7vwpgr" path="res://addons/GameTemplate/GUI/ReBindSection/RemoveActionStyle_Hover.tres" id="2"]
 [ext_resource type="StyleBox" path="res://addons/GameTemplate/GUI/ReBindSection/RemoveActionStyle_Pressed.tres" id="3"]
 [ext_resource type="StyleBox" path="res://addons/GameTemplate/GUI/ReBindSection/RemoveActionStyle_Normal.tres" id="4"]
@@ -95,7 +96,7 @@ theme_override_styles/panel = SubResource("1")
 layout_mode = 2
 size_flags_horizontal = 0
 size_flags_vertical = 0
-theme_override_fonts/font = SubResource("FontFile_6p666")
+theme_override_fonts/font = ExtResource("1_e6q6x")
 theme_override_font_sizes/font_size = 18
 text = "Button"
 

--- a/GameTemplate/addons/GameTemplate/GUI/ReBindSection/ControlBind.tscn
+++ b/GameTemplate/addons/GameTemplate/GUI/ReBindSection/ControlBind.tscn
@@ -73,6 +73,11 @@ cache/0/12/0/descent = 0.0
 cache/0/12/0/underline_position = 0.0
 cache/0/12/0/underline_thickness = 0.0
 cache/0/12/0/scale = 1.0
+cache/0/18/0/ascent = 0.0
+cache/0/18/0/descent = 0.0
+cache/0/18/0/underline_position = 0.0
+cache/0/18/0/underline_thickness = 0.0
+cache/0/18/0/scale = 1.0
 
 [node name="Control" type="HBoxContainer"]
 offset_top = 13.0
@@ -91,6 +96,7 @@ layout_mode = 2
 size_flags_horizontal = 0
 size_flags_vertical = 0
 theme_override_fonts/font = SubResource("FontFile_6p666")
+theme_override_font_sizes/font_size = 18
 text = "Button"
 
 [node name="RemoveAction" type="Button" parent="." groups=["ContainerFocus"]]
@@ -100,6 +106,7 @@ theme_override_colors/font_hover_color = Color(1, 1, 1, 1)
 theme_override_colors/font_pressed_color = Color(1, 1, 1, 1)
 theme_override_colors/font_color = Color(0.752941, 0.752941, 0.752941, 1)
 theme_override_fonts/font = SubResource("FontFile_6p666")
+theme_override_font_sizes/font_size = 18
 theme_override_styles/focus = ExtResource("2")
 theme_override_styles/disabled = ExtResource("4")
 theme_override_styles/hover_pressed = ExtResource("2")

--- a/GameTemplate/addons/GameTemplate/GUI/ReBindSection/ControlBind.tscn
+++ b/GameTemplate/addons/GameTemplate/GUI/ReBindSection/ControlBind.tscn
@@ -1,65 +1,109 @@
-[gd_scene load_steps=7 format=2]
+[gd_scene load_steps=7 format=3 uid="uid://bbq38gdhhvg6i"]
 
-[ext_resource path="res://addons/GameTemplate/Assets/Fonts/pixellocale_8.tres" type="DynamicFont" id=1]
-[ext_resource path="res://addons/GameTemplate/GUI/ReBindSection/RemoveActionStyle_Hover.tres" type="StyleBox" id=2]
-[ext_resource path="res://addons/GameTemplate/GUI/ReBindSection/RemoveActionStyle_Pressed.tres" type="StyleBox" id=3]
-[ext_resource path="res://addons/GameTemplate/GUI/ReBindSection/RemoveActionStyle_Normal.tres" type="StyleBox" id=4]
+[ext_resource type="FontFile" uid="uid://cj1os0is1qn2h" path="res://addons/GameTemplate/Assets/Fonts/pixellocale-v-1-4.ttf" id="1_nh66a"]
+[ext_resource type="StyleBox" uid="uid://cwcup4b7vwpgr" path="res://addons/GameTemplate/GUI/ReBindSection/RemoveActionStyle_Hover.tres" id="2"]
+[ext_resource type="StyleBox" path="res://addons/GameTemplate/GUI/ReBindSection/RemoveActionStyle_Pressed.tres" id="3"]
+[ext_resource type="StyleBox" path="res://addons/GameTemplate/GUI/ReBindSection/RemoveActionStyle_Normal.tres" id="4"]
 
-[sub_resource type="StyleBoxFlat" id=1]
+[sub_resource type="StyleBoxFlat" id="1"]
 content_margin_left = 16.0
 content_margin_top = 0.0
 content_margin_bottom = 2.0
-bg_color = Color( 0.227451, 0.266667, 0.4, 1 )
+bg_color = Color(0.227451, 0.266667, 0.4, 1)
 corner_detail = 1
 anti_aliasing = false
 
-[sub_resource type="StyleBoxFlat" id=2]
-content_margin_left = 4.0
-content_margin_right = 3.0
-bg_color = Color( 0.227451, 0.266667, 0.4, 1 )
-draw_center = false
-corner_detail = 1
-anti_aliasing = false
+[sub_resource type="FontFile" id="FontFile_6p666"]
+fallbacks = Array[Font]([ExtResource("1_nh66a")])
+subpixel_positioning = 0
+msdf_pixel_range = 14
+msdf_size = 128
+cache/0/16/0/ascent = 0.0
+cache/0/16/0/descent = 0.0
+cache/0/16/0/underline_position = 0.0
+cache/0/16/0/underline_thickness = 0.0
+cache/0/16/0/scale = 1.0
+cache/0/50/0/ascent = 0.0
+cache/0/50/0/descent = 0.0
+cache/0/50/0/underline_position = 0.0
+cache/0/50/0/underline_thickness = 0.0
+cache/0/50/0/scale = 1.0
+cache/0/7/0/ascent = 0.0
+cache/0/7/0/descent = 0.0
+cache/0/7/0/underline_position = 0.0
+cache/0/7/0/underline_thickness = 0.0
+cache/0/7/0/scale = 1.0
+cache/0/8/0/ascent = 0.0
+cache/0/8/0/descent = 0.0
+cache/0/8/0/underline_position = 0.0
+cache/0/8/0/underline_thickness = 0.0
+cache/0/8/0/scale = 1.0
+cache/0/9/0/ascent = 0.0
+cache/0/9/0/descent = 0.0
+cache/0/9/0/underline_position = 0.0
+cache/0/9/0/underline_thickness = 0.0
+cache/0/9/0/scale = 1.0
+cache/0/10/0/ascent = 0.0
+cache/0/10/0/descent = 0.0
+cache/0/10/0/underline_position = 0.0
+cache/0/10/0/underline_thickness = 0.0
+cache/0/10/0/scale = 1.0
+cache/0/11/0/ascent = 0.0
+cache/0/11/0/descent = 0.0
+cache/0/11/0/underline_position = 0.0
+cache/0/11/0/underline_thickness = 0.0
+cache/0/11/0/scale = 1.0
+cache/0/15/0/ascent = 0.0
+cache/0/15/0/descent = 0.0
+cache/0/15/0/underline_position = 0.0
+cache/0/15/0/underline_thickness = 0.0
+cache/0/15/0/scale = 1.0
+cache/0/14/0/ascent = 0.0
+cache/0/14/0/descent = 0.0
+cache/0/14/0/underline_position = 0.0
+cache/0/14/0/underline_thickness = 0.0
+cache/0/14/0/scale = 1.0
+cache/0/13/0/ascent = 0.0
+cache/0/13/0/descent = 0.0
+cache/0/13/0/underline_position = 0.0
+cache/0/13/0/underline_thickness = 0.0
+cache/0/13/0/scale = 1.0
+cache/0/12/0/ascent = 0.0
+cache/0/12/0/descent = 0.0
+cache/0/12/0/underline_position = 0.0
+cache/0/12/0/underline_thickness = 0.0
+cache/0/12/0/scale = 1.0
 
 [node name="Control" type="HBoxContainer"]
-margin_top = 13.0
-margin_right = 310.0
-margin_bottom = 33.0
+offset_top = 13.0
+offset_right = 310.0
+offset_bottom = 33.0
 size_flags_horizontal = 3
-custom_constants/separation = 0
-__meta__ = {
-"_edit_use_anchors_": false
-}
+theme_override_constants/separation = 0
 
 [node name="PanelContainer" type="PanelContainer" parent="."]
-margin_right = 298.0
-margin_bottom = 20.0
+layout_mode = 2
 size_flags_horizontal = 3
-custom_styles/panel = SubResource( 1 )
+theme_override_styles/panel = SubResource("1")
 
 [node name="Name" type="Label" parent="PanelContainer"]
-margin_left = 16.0
-margin_right = 53.0
-margin_bottom = 18.0
+layout_mode = 2
 size_flags_horizontal = 0
 size_flags_vertical = 0
-custom_fonts/font = ExtResource( 1 )
+theme_override_fonts/font = SubResource("FontFile_6p666")
 text = "Button"
 
-[node name="RemoveAction" type="Button" parent="." groups=[
-"ContainerFocus",
-]]
-margin_left = 298.0
-margin_right = 310.0
-margin_bottom = 20.0
-hint_tooltip = "Remove control bind"
-custom_styles/hover = ExtResource( 2 )
-custom_styles/pressed = ExtResource( 3 )
-custom_styles/focus = SubResource( 2 )
-custom_styles/disabled = ExtResource( 4 )
-custom_styles/normal = ExtResource( 4 )
-custom_fonts/font = ExtResource( 1 )
-custom_colors/font_color = Color( 0.752941, 0.752941, 0.752941, 1 )
-custom_colors/font_color_hover = Color( 1, 1, 1, 1 )
-custom_colors/font_color_pressed = Color( 1, 1, 1, 1 )
+[node name="RemoveAction" type="Button" parent="." groups=["ContainerFocus"]]
+layout_mode = 2
+tooltip_text = "Remove control bind"
+theme_override_colors/font_hover_color = Color(1, 1, 1, 1)
+theme_override_colors/font_pressed_color = Color(1, 1, 1, 1)
+theme_override_colors/font_color = Color(0.752941, 0.752941, 0.752941, 1)
+theme_override_fonts/font = SubResource("FontFile_6p666")
+theme_override_styles/focus = ExtResource("2")
+theme_override_styles/disabled = ExtResource("4")
+theme_override_styles/hover_pressed = ExtResource("2")
+theme_override_styles/hover = ExtResource("2")
+theme_override_styles/pressed = ExtResource("3")
+theme_override_styles/normal = ExtResource("4")
 text = "-"

--- a/GameTemplate/addons/GameTemplate/GUI/ReBindSection/RemoveActionStyle_Hover.tres
+++ b/GameTemplate/addons/GameTemplate/GUI/ReBindSection/RemoveActionStyle_Hover.tres
@@ -1,8 +1,8 @@
-[gd_resource type="StyleBoxFlat" format=2]
+[gd_resource type="StyleBoxFlat" format=3 uid="uid://cwcup4b7vwpgr"]
 
 [resource]
 content_margin_left = 4.0
 content_margin_right = 3.0
-bg_color = Color( 0, 0.584314, 0.913725, 1 )
+bg_color = Color(0, 0.584314, 0.913725, 1)
 corner_detail = 1
 anti_aliasing = false

--- a/GameTemplate/addons/GameTemplate/GUI/default_theme.tres
+++ b/GameTemplate/addons/GameTemplate/GUI/default_theme.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Theme" load_steps=17 format=3 uid="uid://bjy6d6iusj4lk"]
+[gd_resource type="Theme" load_steps=16 format=3 uid="uid://bjy6d6iusj4lk"]
 
 [ext_resource type="Texture2D" uid="uid://c3texvstwa4yx" path="res://addons/GameTemplate/Assets/Images/SliderGrabber1.png" id="1_b2tq0"]
 [ext_resource type="Texture2D" uid="uid://b3jtgefxnf8bp" path="res://addons/GameTemplate/Assets/Images/Toggle1.png" id="1_yffeu"]
@@ -60,66 +60,9 @@ border_width_bottom = 1
 corner_detail = 1
 anti_aliasing = false
 
-[sub_resource type="FontFile" id="FontFile_6p666"]
-fallbacks = Array[Font]([ExtResource("2_05ycc")])
-cache/0/16/0/ascent = 0.0
-cache/0/16/0/descent = 0.0
-cache/0/16/0/underline_position = 0.0
-cache/0/16/0/underline_thickness = 0.0
-cache/0/16/0/scale = 1.0
-cache/0/50/0/ascent = 0.0
-cache/0/50/0/descent = 0.0
-cache/0/50/0/underline_position = 0.0
-cache/0/50/0/underline_thickness = 0.0
-cache/0/50/0/scale = 1.0
-cache/0/7/0/ascent = 0.0
-cache/0/7/0/descent = 0.0
-cache/0/7/0/underline_position = 0.0
-cache/0/7/0/underline_thickness = 0.0
-cache/0/7/0/scale = 1.0
-cache/0/8/0/ascent = 0.0
-cache/0/8/0/descent = 0.0
-cache/0/8/0/underline_position = 0.0
-cache/0/8/0/underline_thickness = 0.0
-cache/0/8/0/scale = 1.0
-cache/0/9/0/ascent = 0.0
-cache/0/9/0/descent = 0.0
-cache/0/9/0/underline_position = 0.0
-cache/0/9/0/underline_thickness = 0.0
-cache/0/9/0/scale = 1.0
-cache/0/10/0/ascent = 0.0
-cache/0/10/0/descent = 0.0
-cache/0/10/0/underline_position = 0.0
-cache/0/10/0/underline_thickness = 0.0
-cache/0/10/0/scale = 1.0
-cache/0/11/0/ascent = 0.0
-cache/0/11/0/descent = 0.0
-cache/0/11/0/underline_position = 0.0
-cache/0/11/0/underline_thickness = 0.0
-cache/0/11/0/scale = 1.0
-cache/0/15/0/ascent = 0.0
-cache/0/15/0/descent = 0.0
-cache/0/15/0/underline_position = 0.0
-cache/0/15/0/underline_thickness = 0.0
-cache/0/15/0/scale = 1.0
-cache/0/14/0/ascent = 0.0
-cache/0/14/0/descent = 0.0
-cache/0/14/0/underline_position = 0.0
-cache/0/14/0/underline_thickness = 0.0
-cache/0/14/0/scale = 1.0
-cache/0/13/0/ascent = 0.0
-cache/0/13/0/descent = 0.0
-cache/0/13/0/underline_position = 0.0
-cache/0/13/0/underline_thickness = 0.0
-cache/0/13/0/scale = 1.0
-cache/0/12/0/ascent = 0.0
-cache/0/12/0/descent = 0.0
-cache/0/12/0/underline_position = 0.0
-cache/0/12/0/underline_thickness = 0.0
-cache/0/12/0/scale = 1.0
-
 [resource]
-default_font = SubResource("FontFile_6p666")
+default_font = ExtResource("2_05ycc")
+default_font_size = 9
 CheckButton/icons/checked = ExtResource("2_fwsv2")
 CheckButton/icons/unchecked = ExtResource("1_yffeu")
 HSlider/styles/grabber_area = SubResource("StyleBoxTexture_t0i6d")

--- a/GameTemplate/addons/GameTemplate/GUI/default_theme.tres
+++ b/GameTemplate/addons/GameTemplate/GUI/default_theme.tres
@@ -1,20 +1,36 @@
-[gd_resource type="Theme" load_steps=9 format=2]
+[gd_resource type="Theme" load_steps=17 format=3 uid="uid://bjy6d6iusj4lk"]
 
-[ext_resource path="res://addons/GameTemplate/Assets/Fonts/pixellocale_8.tres" type="DynamicFont" id=1]
-[ext_resource path="res://addons/GameTemplate/Assets/Fonts/pixellocale-v-1-4.ttf" type="DynamicFontData" id=2]
-[ext_resource path="res://addons/GameTemplate/GUI/ReBindSection/AddActionStyle_Normal.tres" type="StyleBox" id=3]
+[ext_resource type="Texture2D" uid="uid://c3texvstwa4yx" path="res://addons/GameTemplate/Assets/Images/SliderGrabber1.png" id="1_b2tq0"]
+[ext_resource type="Texture2D" uid="uid://b3jtgefxnf8bp" path="res://addons/GameTemplate/Assets/Images/Toggle1.png" id="1_yffeu"]
+[ext_resource type="FontFile" uid="uid://cj1os0is1qn2h" path="res://addons/GameTemplate/Assets/Fonts/pixellocale-v-1-4.ttf" id="2_05ycc"]
+[ext_resource type="Texture2D" uid="uid://bqyndunb1t7o7" path="res://addons/GameTemplate/Assets/Images/Toggle2.png" id="2_fwsv2"]
+[ext_resource type="Texture2D" uid="uid://unw2786rna32" path="res://addons/GameTemplate/Assets/Images/SliderGrabber2.png" id="2_yn4ya"]
+[ext_resource type="StyleBox" path="res://addons/GameTemplate/GUI/ReBindSection/AddActionStyle_Normal.tres" id="3"]
+[ext_resource type="Texture2D" uid="uid://cmov50y4ytc16" path="res://addons/GameTemplate/Assets/Images/Slider1.png" id="3_poote"]
 
-[sub_resource type="DynamicFont" id=1]
-size = 8
-font_data = ExtResource( 2 )
+[sub_resource type="StyleBoxTexture" id="StyleBoxTexture_t0i6d"]
+texture = ExtResource("1_b2tq0")
 
-[sub_resource type="StyleBoxFlat" id=2]
-bg_color = Color( 0.6, 0.6, 0.6, 0 )
+[sub_resource type="StyleBoxTexture" id="StyleBoxTexture_r8l6r"]
+texture = ExtResource("2_yn4ya")
 
-[sub_resource type="StyleBoxFlat" id=3]
+[sub_resource type="StyleBoxTexture" id="StyleBoxTexture_soroc"]
+texture = ExtResource("3_poote")
+
+[sub_resource type="FontFile" id="1"]
+cache/0/16/0/ascent = 0.0
+cache/0/16/0/descent = 0.0
+cache/0/16/0/underline_position = 0.0
+cache/0/16/0/underline_thickness = 0.0
+cache/0/16/0/scale = 1.0
+
+[sub_resource type="StyleBoxFlat" id="2"]
+bg_color = Color(0.6, 0.6, 0.6, 0)
+
+[sub_resource type="StyleBoxFlat" id="3"]
 content_margin_left = 4.0
 content_margin_right = 3.0
-bg_color = Color( 0.227451, 0.266667, 0.4, 1 )
+bg_color = Color(0.227451, 0.266667, 0.4, 1)
 border_width_left = 1
 border_width_top = 1
 border_width_right = 1
@@ -22,10 +38,10 @@ border_width_bottom = 1
 corner_detail = 1
 anti_aliasing = false
 
-[sub_resource type="StyleBoxFlat" id=4]
+[sub_resource type="StyleBoxFlat" id="4"]
 content_margin_left = 4.0
 content_margin_right = 3.0
-bg_color = Color( 0.0705882, 0.298039, 0.537255, 1 )
+bg_color = Color(0.0705882, 0.298039, 0.537255, 1)
 border_width_left = 1
 border_width_top = 1
 border_width_right = 1
@@ -33,31 +49,94 @@ border_width_bottom = 1
 corner_detail = 1
 anti_aliasing = false
 
-[sub_resource type="StyleBoxFlat" id=5]
+[sub_resource type="StyleBoxFlat" id="5"]
 content_margin_left = 4.0
 content_margin_right = 3.0
-bg_color = Color( 0.227451, 0.266667, 0.4, 1 )
+bg_color = Color(0.227451, 0.266667, 0.4, 1)
 border_width_left = 1
 border_width_top = 1
 border_width_right = 1
 border_width_bottom = 1
 corner_detail = 1
 anti_aliasing = false
+
+[sub_resource type="FontFile" id="FontFile_6p666"]
+fallbacks = Array[Font]([ExtResource("2_05ycc")])
+cache/0/16/0/ascent = 0.0
+cache/0/16/0/descent = 0.0
+cache/0/16/0/underline_position = 0.0
+cache/0/16/0/underline_thickness = 0.0
+cache/0/16/0/scale = 1.0
+cache/0/50/0/ascent = 0.0
+cache/0/50/0/descent = 0.0
+cache/0/50/0/underline_position = 0.0
+cache/0/50/0/underline_thickness = 0.0
+cache/0/50/0/scale = 1.0
+cache/0/7/0/ascent = 0.0
+cache/0/7/0/descent = 0.0
+cache/0/7/0/underline_position = 0.0
+cache/0/7/0/underline_thickness = 0.0
+cache/0/7/0/scale = 1.0
+cache/0/8/0/ascent = 0.0
+cache/0/8/0/descent = 0.0
+cache/0/8/0/underline_position = 0.0
+cache/0/8/0/underline_thickness = 0.0
+cache/0/8/0/scale = 1.0
+cache/0/9/0/ascent = 0.0
+cache/0/9/0/descent = 0.0
+cache/0/9/0/underline_position = 0.0
+cache/0/9/0/underline_thickness = 0.0
+cache/0/9/0/scale = 1.0
+cache/0/10/0/ascent = 0.0
+cache/0/10/0/descent = 0.0
+cache/0/10/0/underline_position = 0.0
+cache/0/10/0/underline_thickness = 0.0
+cache/0/10/0/scale = 1.0
+cache/0/11/0/ascent = 0.0
+cache/0/11/0/descent = 0.0
+cache/0/11/0/underline_position = 0.0
+cache/0/11/0/underline_thickness = 0.0
+cache/0/11/0/scale = 1.0
+cache/0/15/0/ascent = 0.0
+cache/0/15/0/descent = 0.0
+cache/0/15/0/underline_position = 0.0
+cache/0/15/0/underline_thickness = 0.0
+cache/0/15/0/scale = 1.0
+cache/0/14/0/ascent = 0.0
+cache/0/14/0/descent = 0.0
+cache/0/14/0/underline_position = 0.0
+cache/0/14/0/underline_thickness = 0.0
+cache/0/14/0/scale = 1.0
+cache/0/13/0/ascent = 0.0
+cache/0/13/0/descent = 0.0
+cache/0/13/0/underline_position = 0.0
+cache/0/13/0/underline_thickness = 0.0
+cache/0/13/0/scale = 1.0
+cache/0/12/0/ascent = 0.0
+cache/0/12/0/descent = 0.0
+cache/0/12/0/underline_position = 0.0
+cache/0/12/0/underline_thickness = 0.0
+cache/0/12/0/scale = 1.0
 
 [resource]
-default_font = ExtResource( 1 )
-TooltipLabel/colors/font_color = Color( 0, 0, 0, 0 )
-TooltipLabel/colors/font_color_shadow = Color( 0, 0, 0, 0 )
+default_font = SubResource("FontFile_6p666")
+CheckButton/icons/checked = ExtResource("2_fwsv2")
+CheckButton/icons/unchecked = ExtResource("1_yffeu")
+HSlider/styles/grabber_area = SubResource("StyleBoxTexture_t0i6d")
+HSlider/styles/grabber_area_highlight = SubResource("StyleBoxTexture_r8l6r")
+HSlider/styles/slider = SubResource("StyleBoxTexture_soroc")
+TooltipLabel/colors/font_color = Color(0, 0, 0, 0)
+TooltipLabel/colors/font_color_shadow = Color(0, 0, 0, 0)
 TooltipLabel/constants/shadow_offset_x = 1
 TooltipLabel/constants/shadow_offset_y = 1
-TooltipLabel/fonts/font = SubResource( 1 )
-TooltipPanel/styles/panel = SubResource( 2 )
+TooltipLabel/fonts/font = SubResource("1")
+TooltipPanel/styles/panel = SubResource("2")
 VScrollBar/icons/decrement = null
 VScrollBar/icons/decrement_highlight = null
 VScrollBar/icons/increment = null
 VScrollBar/icons/increment_highlight = null
-VScrollBar/styles/grabber = SubResource( 3 )
-VScrollBar/styles/grabber_highlight = SubResource( 4 )
-VScrollBar/styles/grabber_pressed = SubResource( 5 )
-VScrollBar/styles/scroll = ExtResource( 3 )
+VScrollBar/styles/grabber = SubResource("3")
+VScrollBar/styles/grabber_highlight = SubResource("4")
+VScrollBar/styles/grabber_pressed = SubResource("5")
+VScrollBar/styles/scroll = ExtResource("3")
 VScrollBar/styles/scroll_focus = null

--- a/GameTemplate/addons/GameTemplate/GUI/default_theme.tres
+++ b/GameTemplate/addons/GameTemplate/GUI/default_theme.tres
@@ -1,21 +1,15 @@
-[gd_resource type="Theme" load_steps=16 format=3 uid="uid://bjy6d6iusj4lk"]
+[gd_resource type="Theme" load_steps=13 format=3 uid="uid://bjy6d6iusj4lk"]
 
-[ext_resource type="Texture2D" uid="uid://c3texvstwa4yx" path="res://addons/GameTemplate/Assets/Images/SliderGrabber1.png" id="1_b2tq0"]
-[ext_resource type="Texture2D" uid="uid://b3jtgefxnf8bp" path="res://addons/GameTemplate/Assets/Images/Toggle1.png" id="1_yffeu"]
-[ext_resource type="FontFile" uid="uid://cj1os0is1qn2h" path="res://addons/GameTemplate/Assets/Fonts/pixellocale-v-1-4.ttf" id="2_05ycc"]
-[ext_resource type="Texture2D" uid="uid://bqyndunb1t7o7" path="res://addons/GameTemplate/Assets/Images/Toggle2.png" id="2_fwsv2"]
-[ext_resource type="Texture2D" uid="uid://unw2786rna32" path="res://addons/GameTemplate/Assets/Images/SliderGrabber2.png" id="2_yn4ya"]
+[ext_resource type="Texture2D" uid="uid://bqyndunb1t7o7" path="res://addons/GameTemplate/Assets/Images/Toggle2.png" id="1_7y3o3"]
+[ext_resource type="Texture2D" uid="uid://b3jtgefxnf8bp" path="res://addons/GameTemplate/Assets/Images/Toggle1.png" id="2_5pqnj"]
+[ext_resource type="FontFile" uid="uid://c5gjw5i0akjja" path="res://Assets/Fonts/pixellocale-v-1-4.ttf" id="2_hxq8m"]
 [ext_resource type="StyleBox" path="res://addons/GameTemplate/GUI/ReBindSection/AddActionStyle_Normal.tres" id="3"]
-[ext_resource type="Texture2D" uid="uid://cmov50y4ytc16" path="res://addons/GameTemplate/Assets/Images/Slider1.png" id="3_poote"]
 
 [sub_resource type="StyleBoxTexture" id="StyleBoxTexture_t0i6d"]
-texture = ExtResource("1_b2tq0")
 
 [sub_resource type="StyleBoxTexture" id="StyleBoxTexture_r8l6r"]
-texture = ExtResource("2_yn4ya")
 
 [sub_resource type="StyleBoxTexture" id="StyleBoxTexture_soroc"]
-texture = ExtResource("3_poote")
 
 [sub_resource type="FontFile" id="1"]
 cache/0/16/0/ascent = 0.0
@@ -61,10 +55,10 @@ corner_detail = 1
 anti_aliasing = false
 
 [resource]
-default_font = ExtResource("2_05ycc")
-default_font_size = 9
-CheckButton/icons/checked = ExtResource("2_fwsv2")
-CheckButton/icons/unchecked = ExtResource("1_yffeu")
+default_font = ExtResource("2_hxq8m")
+default_font_size = 18
+CheckButton/icons/checked = ExtResource("1_7y3o3")
+CheckButton/icons/unchecked = ExtResource("2_5pqnj")
 HSlider/styles/grabber_area = SubResource("StyleBoxTexture_t0i6d")
 HSlider/styles/grabber_area_highlight = SubResource("StyleBoxTexture_r8l6r")
 HSlider/styles/slider = SubResource("StyleBoxTexture_soroc")

--- a/GameTemplate/addons/GameTemplate/Localization/Localization.csv
+++ b/GameTemplate/addons/GameTemplate/Localization/Localization.csv
@@ -1,8 +1,8 @@
 id,en,de,lv,es,ru,fr,pt_BR,it,sv_SE,tr
-Right,Right,Richtig,Pa Labi,Derecha,Вправо,À droite,Direita,Destra,Höger,Sağ
+Right,Right,Rechts,Pa Labi,Derecha,Вправо,À droite,Direita,Destra,Höger,Sağ
 Left,Left,Links,Pa kreisi,Izquierda,Влево,À gauche,Esquerda,Sinistra,Vänster,Sol
-Up,Up,Oben,Uz augšu,Arriba,Вверх,An haut,Acima,Su,Upp,Yukarı
-Down,Down,Nieder,Uz leju,Abajo,Вниз,Vers le bas,Abaixo,Giù,Ner,Aşağı
+Up,Up,Oben,Uz augšu,Arriba,Вверх,En haut,Acima,Su,Upp,Yukarı
+Down,Down,Unten,Uz leju,Abajo,Вниз,En bas,Abaixo,Giù,Ner,Aşağı
 Jump,Jump,Springen,Lekt,Saltar,Прыжок,Sauter,Saltar,Saltare,Hoppa,Zıpla
 Shoot,Shoot,Schießen,Šaut,Disparar,Огонь,Tirer,Atirar,Sparare,Skjut,Ateş
 NEW_GAME,New game,Neues Spiel,Jauna spēle,Nuevo juego,Новая игра,Nouveau jeu,Novo jogo,Nuova partita,Nytt spel,Yeni oyun
@@ -12,22 +12,22 @@ RESTART,Restart,Neustart,Restartēt,Reiniciar,Заново,Redémarrer,Reiniciar
 OPTIONS,Options,Optionen,Iespējas,Opciones,Опции,Options,Opções,Opzioni,Inställningar,Ayarlar
 MAIN_MENU,Main Menu,Hauptmenü,Galvenā izvēlne,Menú principal,Главное меню,Menu principal,Menu principal,Menu principale,Huvudmeny,Anamenü
 BACK,Back,Zurück,Atpakaļ,Atrás,Назад,Retour,Voltar,Indietro,Bakåt,Geri
-EXIT,Exit,Ausgang,Iziet no spēles,Salir,Выход,Sortie,Sair,Esci,Avsluta,Çıkış
+EXIT,Exit,Beenden,Iziet no spēles,Salir,Выход,Sortie,Sair,Esci,Avsluta,Çıkış
 PAUSE,Pause,Pause,Pauze,Pausa,Пауза,Pause,Pausa,Pausa,Pausa,Durdur
 LOADING,Loading,Wird geladen,Lādējās,Cargando,Загрузка,Chargement,Carregando,Caricamento,Laddar,Yükleniyor
 RESOLUTION,Resolution,Auflösung,Izšķirtspēja,Resolución,Pазрешение,Résolution,Resolução,Risoluzione,Upplösning,Çözünürlük
 FULLSCREEN,Fullscreen window,Vollbild-Fenster,Pilnekrāns,Pantalla completa,Полноэкранный,Plein écran,Tela cheia,Schermo interno,Helskärm,Tam ekran
-BORDERLESS,Borderless window,Randlos Fenster,Bezmalu ekrāns,Pantalla sin bordes,Безрамочный,Sans bordure,Sem bordas,Senza bordi,Ramlöst fönster,Kenarlıksız pencere
-SCALE,Scale,Rahmen,Palielinājums,Escalado,Маштабирование,Échelle,Escala,Scala,Skala,Boyut
-VOLUME,Volume,Lautstärke,Skaļums,Volumen,Громкость,Le volume,Volume,Volume,Volym,Ses
-MASTER,Master,Meister,Galvenais,General,Мастер,Maître,Principal,Principale,Alla,Oyun
-MUSIC,Music,Musik,Mūzika,Música,Музыка,La musique,Música,Musica,Musik,Müzik
-SFX,Sounds,Geräusche,Skaņu efekti,Efectos de Sonido,Звуки,Des sons,Efeitos,Suoni,Effekter,Ses Efektleri
+BORDERLESS,Borderless window,Randloses Fenster,Bezmalu ekrāns,Pantalla sin bordes,Безрамочный,Sans bordure,Sem bordas,Senza bordi,Ramlöst fönster,Kenarlıksız pencere
+SCALE,Scale,Skalierung,Palielinājums,Escalado,Маштабирование,Échelle,Escala,Scala,Skala,Boyut
+VOLUME,Volume,Lautstärke,Skaļums,Volumen,Громкость,Volume,Volume,Volume,Volym,Ses
+MASTER,Master,Gesamt,Galvenais,General,Мастер,Principal,Principal,Principale,Alla,Oyun
+MUSIC,Music,Musik,Mūzika,Música,Музыка,Musique,Música,Musica,Musik,Müzik
+SFX,Sounds,Geräusche,Skaņu efekti,Efectos de Sonido,Звуки,Effet sonore,Efeitos,Suoni,Effekter,Ses Efektleri
 CONTROLS,Controls,Steuerung,Kontroles,Controles,Управления,Controles,Controles,Controlli,Kontroller,Kontroller
-ACTIONS,Actions,Aktionen,Darbība,Acciones,Действия,Actes,Ações,Azioni,Actions,Hareketler
+ACTIONS,Actions,Aktionen,Darbība,Acciones,Действия,Actions,Ações,Azioni,Actions,Hareketler
 KEYBOARD,Keyboard,Tastatur,Klaviatūra,Teclado,Клавиатура,Clavier,Teclado,Tastiera,Tangentbord,Klavye
 GAMEPAD,Gamepad,Gamepad,Spēļu pūlts,Gamepad,Геймпад,Gamepad,Controle,Gamepad,Gamepad,Gamepad
 DEFAULT,Default,Standard,Noklusējums,Defecto,По умолчанию,Défaut,Padrão,Predefinito,Standard,Standart
-USE_NEW_CONTROLS,Use new control!,Verwenden Sie neue Kontrolle!,Izmantojiet jauno kontroli!,Usar nuevos controles!,Используйте новый элемент управления!,Utilisez un nouveau contrôle!,Use novo controle!,Usa nuovi controlli!,Använd nya kontroller,Yeni kontrol kullan!
-CANCEL,Cancel,Stornieren,Atcelt,Cancelar,Отмена,Annuler,Cancelar,Annulla,Avbryt,İptal
+USE_NEW_CONTROLS,Use new control!,Verwenden Sie eine neue Taste!,Izmantojiet jauno kontroli!,Usar nuevos controles!,Используйте новый элемент управления!,Utilisez un nouveau contrôle!,Use novo controle!,Usa nuovi controlli!,Använd nya kontroller,Yeni kontrol kullan!
+CANCEL,Cancel,Abbrechen,Atcelt,Cancelar,Отмена,Annuler,Cancelar,Annulla,Avbryt,İptal
 LANGUAGES,Languages,Sprachen,Valodas,Idiomas,Языки,Langues,Idiomas,Lingue,Språk,Diller

--- a/GameTemplate/addons/GameTemplate/Localization/Localization.csv.import
+++ b/GameTemplate/addons/GameTemplate/Localization/Localization.csv.import
@@ -2,13 +2,14 @@
 
 importer="csv_translation"
 type="Translation"
+uid="uid://c3rcs28ogbs6v"
 
 [deps]
 
-files=[ "res://addons/GameTemplate/Localization/Localization.en.translation", "res://addons/GameTemplate/Localization/Localization.de.translation", "res://addons/GameTemplate/Localization/Localization.lv.translation", "res://addons/GameTemplate/Localization/Localization.es.translation", "res://addons/GameTemplate/Localization/Localization.ru.translation", "res://addons/GameTemplate/Localization/Localization.fr.translation", "res://addons/GameTemplate/Localization/Localization.pt_BR.translation", "res://addons/GameTemplate/Localization/Localization.it.translation", "res://addons/GameTemplate/Localization/Localization.sv_SE.translation", "res://addons/GameTemplate/Localization/Localization.tr.translation" ]
+files=["res://addons/GameTemplate/Localization/Localization.en.translation", "res://addons/GameTemplate/Localization/Localization.de.translation", "res://addons/GameTemplate/Localization/Localization.lv.translation", "res://addons/GameTemplate/Localization/Localization.es.translation", "res://addons/GameTemplate/Localization/Localization.ru.translation", "res://addons/GameTemplate/Localization/Localization.fr.translation", "res://addons/GameTemplate/Localization/Localization.pt_BR.translation", "res://addons/GameTemplate/Localization/Localization.it.translation", "res://addons/GameTemplate/Localization/Localization.sv_SE.translation", "res://addons/GameTemplate/Localization/Localization.tr.translation"]
 
 source_file="res://addons/GameTemplate/Localization/Localization.csv"
-dest_files=[ "res://addons/GameTemplate/Localization/Localization.en.translation", "res://addons/GameTemplate/Localization/Localization.de.translation", "res://addons/GameTemplate/Localization/Localization.lv.translation", "res://addons/GameTemplate/Localization/Localization.es.translation", "res://addons/GameTemplate/Localization/Localization.ru.translation", "res://addons/GameTemplate/Localization/Localization.fr.translation", "res://addons/GameTemplate/Localization/Localization.pt_BR.translation", "res://addons/GameTemplate/Localization/Localization.it.translation", "res://addons/GameTemplate/Localization/Localization.sv_SE.translation", "res://addons/GameTemplate/Localization/Localization.tr.translation" ]
+dest_files=["res://addons/GameTemplate/Localization/Localization.en.translation", "res://addons/GameTemplate/Localization/Localization.de.translation", "res://addons/GameTemplate/Localization/Localization.lv.translation", "res://addons/GameTemplate/Localization/Localization.es.translation", "res://addons/GameTemplate/Localization/Localization.ru.translation", "res://addons/GameTemplate/Localization/Localization.fr.translation", "res://addons/GameTemplate/Localization/Localization.pt_BR.translation", "res://addons/GameTemplate/Localization/Localization.it.translation", "res://addons/GameTemplate/Localization/Localization.sv_SE.translation", "res://addons/GameTemplate/Localization/Localization.tr.translation"]
 
 [params]
 

--- a/GameTemplate/addons/GameTemplate/Utility/ResourceAsyncLoader.gd
+++ b/GameTemplate/addons/GameTemplate/Utility/ResourceAsyncLoader.gd
@@ -10,7 +10,7 @@ signal done
 var thread: = Thread.new()
 var mutex: = Mutex.new()
 
-var can_async:bool = !Settings.HTML5 and (OS.get_processor_count() > 1)
+var can_async:bool = !OS.has_feature('web') and (OS.get_processor_count() > 1)
 
 func load_start(resource_list:Array)->Array:
 	var resources_in = resource_list.duplicate()

--- a/GameTemplate/addons/GameTemplate/Utility/ResourceAsyncLoader.gd
+++ b/GameTemplate/addons/GameTemplate/Utility/ResourceAsyncLoader.gd
@@ -10,7 +10,7 @@ signal done
 var thread: = Thread.new()
 var mutex: = Mutex.new()
 
-var can_async:bool = OS.get_processor_count() > 1
+var can_async:bool = !Settings.HTML5 and (OS.get_processor_count() > 1)
 
 func load_start(resource_list:Array)->Array:
 	var resources_in = resource_list.duplicate()
@@ -25,7 +25,6 @@ func load_start(resource_list:Array)->Array:
 
 func threaded_load(resources_in:Array)->void:
 	var resources_out: = []
-	
 	for res_in in resources_in:
 		mutex.lock()
 		resources_out.append(load(res_in))

--- a/GameTemplate/addons/GameTemplate/Utility/ResourceAsyncLoader.gd
+++ b/GameTemplate/addons/GameTemplate/Utility/ResourceAsyncLoader.gd
@@ -10,14 +10,14 @@ signal done
 var thread: = Thread.new()
 var mutex: = Mutex.new()
 
-var can_async:bool = OS.can_use_threads()
+var can_async:bool = OS.get_processor_count() > 1
 
 func load_start(resource_list:Array)->Array:
 	var resources_in = resource_list.duplicate()
 	var out: = []
 	if can_async:
-		thread.start(self, 'threaded_load', resources_in)
-		out = yield(self, "done")
+		thread.start(threaded_load.bind(resources_in))
+		out = await self.done
 		thread.wait_to_finish()
 	else:
 		out = regular_load(resources_in)

--- a/GameTemplate/addons/GameTemplate/Utility/SaveSettings.gd
+++ b/GameTemplate/addons/GameTemplate/Utility/SaveSettings.gd
@@ -1,7 +1,7 @@
 extends Resource
 class_name SaveSettings
 
-export(Dictionary) 	var resolution: Dictionary
-export(Dictionary)	var audio: 		Dictionary
-export(Dictionary)	var inputs: 	Dictionary
-export(String)		var language: 	String
+@export var resolution: Dictionary
+@export var audio: Dictionary
+@export var inputs: Dictionary
+@export var language: String

--- a/GameTemplate/addons/GameTemplate/plugin.gd
+++ b/GameTemplate/addons/GameTemplate/plugin.gd
@@ -1,4 +1,4 @@
-tool
+@tool
 extends EditorPlugin
 
 const autoload_order: = [
@@ -49,9 +49,9 @@ func _exit_tree():
 		remove_autoload_singleton(key)
 
 
-func has_main_screen():
+func _has_main_screen():
 	return false
 
 
-func get_plugin_name():
+func _get_plugin_name():
 	return "GameTemplate"

--- a/GameTemplate/default_env.tres
+++ b/GameTemplate/default_env.tres
@@ -1,7 +1,7 @@
-[gd_resource type="Environment" load_steps=2 format=2]
+[gd_resource type="Environment" load_steps=2 format=3 uid="uid://bb3ae2foj435p"]
 
-[sub_resource type="ProceduralSky" id=1]
+[sub_resource type="Sky" id="1"]
 
 [resource]
 background_mode = 2
-background_sky = SubResource( 1 )
+sky = SubResource("1")

--- a/GameTemplate/icon.png.import
+++ b/GameTemplate/icon.png.import
@@ -2,7 +2,7 @@
 
 importer="texture"
 type="CompressedTexture2D"
-uid="uid://cb0tbpriomwqd"
+uid="uid://ctghwtp0t782j"
 path="res://.godot/imported/icon.png-487276ed1e3a0c39cad0279d744ee560.ctex"
 metadata={
 "vram_texture": false

--- a/GameTemplate/icon.png.import
+++ b/GameTemplate/icon.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex"
+type="CompressedTexture2D"
+uid="uid://cb0tbpriomwqd"
+path="res://.godot/imported/icon.png-487276ed1e3a0c39cad0279d744ee560.ctex"
 metadata={
 "vram_texture": false
 }
@@ -10,25 +11,24 @@ metadata={
 [deps]
 
 source_file="res://icon.png"
-dest_files=[ "res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex" ]
+dest_files=["res://.godot/imported/icon.png-487276ed1e3a0c39cad0279d744ee560.ctex"]
 
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
-compress/hdr_mode=0
-compress/bptc_ldr=0
+compress/hdr_compression=1
 compress/normal_map=0
-flags/repeat=0
-flags/filter=false
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
-process/HDR_as_SRGB=false
-process/invert_color=false
-stream=false
-size_limit=0
-detect_3d=false
-svg/scale=1.0
+process/normal_map_invert_y=false
+process/hdr_as_srgb=false
+process/hdr_clamp_exposure=false
+process/size_limit=0
+detect_3d/compress_to=1

--- a/GameTemplate/project.godot
+++ b/GameTemplate/project.godot
@@ -6,29 +6,18 @@
 ;   [section] ; section goes between []
 ;   param=value ; assign values to parameters
 
-config_version=4
-
-_global_script_classes=[ {
-"base": "Reference",
-"class": "ResourceAsyncLoader",
-"language": "GDScript",
-"path": "res://addons/GameTemplate/Utility/ResourceAsyncLoader.gd"
-}, {
-"base": "Resource",
-"class": "SaveSettings",
-"language": "GDScript",
-"path": "res://addons/GameTemplate/Utility/SaveSettings.gd"
-} ]
-_global_script_class_icons={
-"ResourceAsyncLoader": "",
-"SaveSettings": ""
-}
+config_version=5
 
 [application]
 
 config/name="GameTemplate"
 run/main_scene="res://MainMenu/MainMenu.tscn"
+config/features=PackedStringArray("4.3")
 config/icon="res://icon.png"
+
+[audio]
+
+buses/default_bus_layout="res://addons/GameTemplate/Assets/Audio_bus_layout.tres"
 
 [autoload]
 
@@ -52,22 +41,23 @@ HtmlFocus="*res://addons/GameTemplate/Autoload/HtmlFocus.tscn"
 
 gdscript/warnings/unassigned_variable=false
 gdscript/warnings/unused_variable=false
-gdscript/warnings/narrowing_conversion=false
 gdscript/warnings/unused_signal=false
 gdscript/warnings/return_value_discarded=false
+gdscript/warnings/narrowing_conversion=false
 
 [display]
 
-window/size/width=320
-window/size/height=180
-window/size/test_width=1280
-window/size/test_height=720
-window/stretch/mode="2d"
+window/size/viewport_width=480
+window/size/viewport_height=270
+window/size/window_width_override=1920
+window/size/window_height_override=1080
+window/stretch/mode="viewport"
 window/stretch/aspect="keep_height"
+window/stretch/scale_mode="integer"
 
 [editor_plugins]
 
-enabled=PoolStringArray( "GameTemplate" )
+enabled=PackedStringArray("GameTemplate")
 
 [importer_defaults]
 
@@ -96,88 +86,70 @@ texture={
 
 ui_accept={
 "deadzone": 0.5,
-"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777221,"unicode":0,"echo":false,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777222,"unicode":0,"echo":false,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":32,"unicode":0,"echo":false,"script":null)
-, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":0,"pressure":0.0,"pressed":false,"script":null)
- ]
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":4194309,"physical_keycode":0,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":4194310,"physical_keycode":0,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":32,"physical_keycode":0,"key_label":0,"unicode":32,"location":0,"echo":false,"script":null)
+, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":0,"pressure":0.0,"pressed":true,"script":null)
+]
 }
 ui_select={
 "deadzone": 0.5,
-"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":32,"unicode":0,"echo":false,"script":null)
- ]
+"events": [Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":6,"pressure":0.0,"pressed":true,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194305,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+]
 }
 ui_cancel={
 "deadzone": 0.5,
-"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777217,"unicode":0,"echo":false,"script":null)
-, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":11,"pressure":0.0,"pressed":false,"script":null)
- ]
-}
-ui_left={
-"deadzone": 0.5,
-"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777231,"unicode":0,"echo":false,"script":null)
-, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":14,"pressure":0.0,"pressed":false,"script":null)
- ]
-}
-ui_right={
-"deadzone": 0.5,
-"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777233,"unicode":0,"echo":false,"script":null)
-, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":15,"pressure":0.0,"pressed":false,"script":null)
- ]
-}
-ui_down={
-"deadzone": 0.5,
-"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777234,"unicode":0,"echo":false,"script":null)
-, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":13,"pressure":0.0,"pressed":false,"script":null)
- ]
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":4194305,"physical_keycode":0,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":1,"pressure":0.0,"pressed":true,"script":null)
+]
 }
 Right={
 "deadzone": 0.5,
-"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":68,"unicode":0,"echo":false,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777233,"unicode":0,"echo":false,"script":null)
-, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":15,"pressure":0.0,"pressed":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":68,"physical_keycode":0,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":4194321,"physical_keycode":0,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":14,"pressure":0.0,"pressed":false,"script":null)
 , Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":0,"axis":0,"axis_value":1.0,"script":null)
- ]
+]
 }
 Left={
 "deadzone": 0.5,
-"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":65,"unicode":0,"echo":false,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777231,"unicode":0,"echo":false,"script":null)
-, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":14,"pressure":0.0,"pressed":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":65,"physical_keycode":0,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":4194319,"physical_keycode":0,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":13,"pressure":0.0,"pressed":false,"script":null)
 , Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":0,"axis":0,"axis_value":-1.0,"script":null)
- ]
+]
 }
 Up={
 "deadzone": 0.5,
-"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":87,"unicode":0,"echo":false,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777232,"unicode":0,"echo":false,"script":null)
-, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":12,"pressure":0.0,"pressed":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":87,"physical_keycode":0,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":4194320,"physical_keycode":0,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":11,"pressure":0.0,"pressed":false,"script":null)
 , Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":0,"axis":1,"axis_value":-1.0,"script":null)
- ]
+]
 }
 Down={
 "deadzone": 0.5,
-"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":83,"unicode":0,"echo":false,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777234,"unicode":0,"echo":false,"script":null)
-, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":13,"pressure":0.0,"pressed":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":83,"physical_keycode":0,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":4194322,"physical_keycode":0,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":12,"pressure":0.0,"pressed":false,"script":null)
 , Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":0,"axis":1,"axis_value":1.0,"script":null)
- ]
+]
 }
 Jump={
 "deadzone": 0.5,
-"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":32,"unicode":0,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":32,"physical_keycode":0,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":0,"pressure":0.0,"pressed":false,"script":null)
- ]
+]
 }
 
 [locale]
 
 test="en"
-translations=PoolStringArray(  )
+translations=PackedStringArray()
 
 [rendering]
 
+environment/defaults/default_environment="res://default_env.tres"
 quality/driver/driver_name="GLES2"
 vram_compression/import_etc=true
-vram_compression/import_etc2=false
-environment/default_environment="res://default_env.tres"

--- a/GameTemplate/project.godot
+++ b/GameTemplate/project.godot
@@ -21,9 +21,9 @@ buses/default_bus_layout="res://addons/GameTemplate/Assets/Audio_bus_layout.tres
 
 [autoload]
 
+SettingsLanguage="*res://addons/GameTemplate/Autoload/SettingsLanguage.gd"
 SettingsAudio="*res://addons/GameTemplate/Autoload/SettingsAudio.gd"
 SettingsControls="*res://addons/GameTemplate/Autoload/SettingsControls.gd"
-SettingsLanguage="*res://addons/GameTemplate/Autoload/SettingsLanguage.gd"
 SettingsResolution="*res://addons/GameTemplate/Autoload/SettingsResolution.gd"
 SettingsSaveLoad="*res://addons/GameTemplate/Autoload/SettingsSaveLoad.gd"
 Settings="*res://addons/GameTemplate/Autoload/Settings.gd"

--- a/GameTemplate/project.godot
+++ b/GameTemplate/project.godot
@@ -37,14 +37,6 @@ Music="*res://addons/GameTemplate/Autoload/Music.tscn"
 SfxManager="*res://addons/GameTemplate/Autoload/SfxManager.gd"
 HtmlFocus="*res://addons/GameTemplate/Autoload/HtmlFocus.tscn"
 
-[debug]
-
-gdscript/warnings/unassigned_variable=false
-gdscript/warnings/unused_variable=false
-gdscript/warnings/unused_signal=false
-gdscript/warnings/return_value_discarded=false
-gdscript/warnings/narrowing_conversion=false
-
 [display]
 
 window/size/viewport_width=480
@@ -151,5 +143,5 @@ translations=PackedStringArray()
 [rendering]
 
 environment/defaults/default_environment="res://default_env.tres"
-quality/driver/driver_name="GLES2"
 vram_compression/import_etc=true
+quality/driver/driver_name="GLES3"

--- a/GameTemplate/project.godot
+++ b/GameTemplate/project.godot
@@ -135,6 +135,10 @@ Jump={
 ]
 }
 
+[internationalization]
+
+locale/translations=PackedStringArray("res://addons/GameTemplate/Localization/Localization.de.translation", "res://addons/GameTemplate/Localization/Localization.en.translation", "res://addons/GameTemplate/Localization/Localization.es.translation", "res://addons/GameTemplate/Localization/Localization.fr.translation", "res://addons/GameTemplate/Localization/Localization.it.translation", "res://addons/GameTemplate/Localization/Localization.lv.translation", "res://addons/GameTemplate/Localization/Localization.pt_BR.translation", "res://addons/GameTemplate/Localization/Localization.ru.translation", "res://addons/GameTemplate/Localization/Localization.sv_SE.translation", "res://addons/GameTemplate/Localization/Localization.tr.translation")
+
 [locale]
 
 test="en"

--- a/GameTemplate/saves/settings.tres
+++ b/GameTemplate/saves/settings.tres
@@ -1,9 +1,9 @@
-[gd_resource type="Resource" load_steps=2 format=2]
+[gd_resource type="Resource" script_class="SaveSettings" load_steps=2 format=3 uid="uid://ow6rq1fedwoo"]
 
-[ext_resource path="res://addons/GameTemplate/Utility/Settings_save.gd" type="Script" id=1]
+[ext_resource type="Script" path="res://addons/GameTemplate/Utility/SaveSettings.gd" id="1"]
 
 [resource]
-script = ExtResource( 1 )
+script = ExtResource("1")
 resolution = {
 "Borderless": false,
 "Scale": 3

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 
 # Godot-GameTemplate
-**Game Template** is all necessary stuff taken care for Godot users not to worry about creating most boring and tedious work.  
+**Game Template** some stuff taken care for Godot users not to worry about creating most boring and tedious work.  
 Main branch will be compatible with pixel art games, since those games require some more work to get everything right.  
 I'd be happy for any contribution to make this template as good as it can be and it is open for branching out Hi-Res game branch.  
 
@@ -78,5 +78,3 @@ Buttons gets saved uppon exiting Options menu.
 
 ## To-Do
 * Add pixel-art compliant slider in Action rebinding list
-* Use themes instead of CustomStyle (maybe)
-* Maybe some documentation


### PR DESCRIPTION
Hello,

I spent a little time converting the old project from godot 3 to godot 4. As far as I know, all the items are mostly working the way the original project did. I was using Godot 4.3 Beta 3 at the time of upgrading.

There may be some small unfound bugs or hangups, but this is my new starting point that I'm using for my future projects. Feel free to clone my changes and have this be the new foundation for a v4 branch or something.

This was mostly fixing new GDscript syntaxes, like update tween syntax, using new await properly, fixing the signal connections, gdscript typing syntax changes, updated method names, and also stuff like the new video changes for godot, since it can handle multiple windows.


Other small things I fixed:
- Updated the resolution to be 1080p, starts with base resolution of 480p and does the scaling there (1-4x available)
- Hide scaling options on web
- Changed translation page to use a grid instead of hbox
- made sure resource loader works for single/multi threaded (web uses single threaded to start now for 4.3 for fixing audio bugs IIRC https://godotengine.org/article/progress-report-web-export-in-4-3/)
- edit the font sizes to match the pixellocale font (9px or 18px in components)
- Added gitlab .gitlab-ci.yml for a CI/CD to build/deploy from gitlab pipelins (we should add one for github too)

Things that need to be fixed:
- Gather better input button / joy axis names on rebind screen
- Add which window you're using on video settings page

No worries if you don't end up using it! Just thought I would share.

Let me know if you need help with anything! Thanks again for making such a great starter template for gamedev using Godot :)